### PR TITLE
chown files in Dockerfile to user ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ terraform.tfstate.backup
 tmp/
 workloads/writes/kafka-clients/target
 violations/
-redpanda_0.0-dev-0000000_amd64.deb
+*.deb
 id_ed25519.pub
 id_ed25519
 docker/bind_mounts/

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -13,9 +13,9 @@ RUN usermod -aG sudo -u $USER_ID ubuntu
 RUN echo "ubuntu ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN mkdir -p /mnt/vectorized
 RUN mkdir -p /home/ubuntu/.ssh
-COPY id_ed25519.pub /home/ubuntu/.ssh/authorized_keys
+COPY --chown=ubuntu:ubuntu id_ed25519.pub /home/ubuntu/.ssh/authorized_keys
 COPY docker/client/entrypoint.sh /mnt/vectorized/entrypoint.sh
-COPY control /mnt/vectorized/control
+COPY --chown=ubuntu:ubuntu control /mnt/vectorized/control
 RUN chown ubuntu:ubuntu -R /mnt/vectorized/control
 COPY $REDPANDA_DEB /mnt/vectorized/$REDPANDA_DEB
 RUN dpkg --force-confold -i /mnt/vectorized/$REDPANDA_DEB

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -28,6 +28,6 @@ RUN pip3 install sh
 RUN pip3 install flask
 RUN pip3 install pyyaml
 RUN pip3 install confluent_kafka
-COPY harness /mnt/vectorized/harness
-COPY suites /mnt/vectorized/suites
+COPY --chown=ubuntu:ubuntu harness /mnt/vectorized/harness
+COPY --chown=ubuntu:ubuntu suites /mnt/vectorized/suites
 CMD /mnt/vectorized/entrypoint.sh

--- a/docker/redpanda/Dockerfile
+++ b/docker/redpanda/Dockerfile
@@ -12,9 +12,9 @@ RUN adduser --disabled-password --gecos "" ubuntu
 RUN usermod -aG sudo -u $USER_ID ubuntu
 RUN echo "ubuntu ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN mkdir -p /home/ubuntu/.ssh
-COPY id_ed25519.pub /home/ubuntu/.ssh/authorized_keys
+COPY --chown=ubuntu:ubuntu id_ed25519.pub /home/ubuntu/.ssh/authorized_keys
 RUN mkdir -p /mnt/vectorized
-COPY control /mnt/vectorized/control
+COPY --chown=ubuntu:ubuntu control /mnt/vectorized/control
 RUN chown ubuntu:ubuntu -R /mnt/vectorized/control
 COPY docker/redpanda/entrypoint.sh /mnt/vectorized/entrypoint.sh
 COPY $REDPANDA_DEB /mnt/vectorized/$REDPANDA_DEB


### PR DESCRIPTION
Without this PR, I get a permission denied error when running tests using [instructions](https://github.com/redpanda-data/chaos/tree/5704b6fe8a9b2e474c7087d6a8c10e32b9105c86#test-locally-docker--docker-compose) for docker:
```
bash$ docker/test.test.sh reads_writes/pause_leader.json
python3: can't open file '/mnt/vectorized/harness/test.test.py': [Errno 13] Permission denied
```

This is because some of the files used by user `ubuntu` cannot be accessed, such as `authorized_keys`:
```
bash$ docker exec client1 /bin/ls -l /home/ubuntu/.ssh/
total 4
-rw------- 1 root root 98 Feb 12 00:11 authorized_keys
```

This PR fixes the problem by setting the file ownership using the [Dockerfile COPY --chown](https://docs.docker.com/engine/reference/builder/#copy) arg.