### PR TITLE
install redpanda in docker entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ terraform.tfstate.backup
 tmp/
 workloads/writes/kafka-clients/target
 violations/
-redpanda_0.0-dev-0000000_amd64.deb
+*.deb
 id_ed25519.pub
 id_ed25519
 docker/bind_mounts/

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:20.04
 LABEL maintainer="Denis Rystsov <denis@vectorized.io>"
 ARG DEBIAN_FRONTEND=noninteractive
-ARG REDPANDA_DEB
 ARG USER_ID
 ARG REDPANDA_CLUSTER_SIZE
 ENV REDPANDA_CLUSTER_SIZE=${REDPANDA_CLUSTER_SIZE}
@@ -17,10 +16,6 @@ COPY --chown=ubuntu:ubuntu id_ed25519.pub /home/ubuntu/.ssh/authorized_keys
 COPY docker/client/entrypoint.sh /mnt/vectorized/entrypoint.sh
 COPY --chown=ubuntu:ubuntu control /mnt/vectorized/control
 RUN chown ubuntu:ubuntu -R /mnt/vectorized/control
-COPY $REDPANDA_DEB /mnt/vectorized/$REDPANDA_DEB
-RUN dpkg --force-confold -i /mnt/vectorized/$REDPANDA_DEB
-RUN systemctl disable redpanda
-RUN systemctl disable wasm_engine
 RUN pip3 install sh
 RUN pip3 install flask
 RUN pip3 install confluent_kafka

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -13,9 +13,9 @@ RUN usermod -aG sudo -u $USER_ID ubuntu
 RUN echo "ubuntu ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN mkdir -p /mnt/vectorized
 RUN mkdir -p /home/ubuntu/.ssh
-COPY id_ed25519.pub /home/ubuntu/.ssh/authorized_keys
+COPY --chown=ubuntu:ubuntu id_ed25519.pub /home/ubuntu/.ssh/authorized_keys
 COPY docker/client/entrypoint.sh /mnt/vectorized/entrypoint.sh
-COPY control /mnt/vectorized/control
+COPY --chown=ubuntu:ubuntu control /mnt/vectorized/control
 RUN chown ubuntu:ubuntu -R /mnt/vectorized/control
 COPY $REDPANDA_DEB /mnt/vectorized/$REDPANDA_DEB
 RUN dpkg --force-confold -i /mnt/vectorized/$REDPANDA_DEB

--- a/docker/client/entrypoint.sh
+++ b/docker/client/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [[ ! -r /mnt/vectorized/redpanda.deb ]]; then
   echo 'error: unable to read /mnt/vectorized/redpanda.deb'
   exit 1

--- a/docker/client/entrypoint.sh
+++ b/docker/client/entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+if [[ ! -r /mnt/vectorized/redpanda.deb ]]; then
+  echo 'error: unable to read /mnt/vectorized/redpanda.deb'
+  exit 1
+fi
+
+dpkg --force-confold -i /mnt/vectorized/redpanda.deb
+systemctl disable redpanda
+systemctl disable wasm_engine
+
 declare -A redpandas
 declare -A node_ids
 

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -28,6 +28,6 @@ RUN pip3 install sh
 RUN pip3 install flask
 RUN pip3 install pyyaml
 RUN pip3 install confluent_kafka
-COPY harness /mnt/vectorized/harness
-COPY suites /mnt/vectorized/suites
+COPY --chown=ubuntu:ubuntu harness /mnt/vectorized/harness
+COPY --chown=ubuntu:ubuntu suites /mnt/vectorized/suites
 CMD /mnt/vectorized/entrypoint.sh

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:20.04
 LABEL maintainer="Denis Rystsov <denis@vectorized.io>"
 ARG DEBIAN_FRONTEND=noninteractive
-ARG REDPANDA_DEB
 ARG USER_ID
 ARG REDPANDA_CLUSTER_SIZE
 ENV REDPANDA_CLUSTER_SIZE=${REDPANDA_CLUSTER_SIZE}
@@ -17,10 +16,6 @@ RUN mkdir -p /mnt/vectorized
 RUN mkdir -p /home/ubuntu/.ssh
 COPY id_ed25519 /home/ubuntu/.ssh/id_ed25519
 RUN chown ubuntu:ubuntu -R /home/ubuntu/.ssh
-COPY $REDPANDA_DEB /mnt/vectorized/$REDPANDA_DEB
-RUN dpkg --force-confold -i /mnt/vectorized/$REDPANDA_DEB
-RUN systemctl disable redpanda
-RUN systemctl disable wasm_engine
 COPY docker/control/entrypoint.sh /mnt/vectorized/entrypoint.sh
 COPY docker/control/test.test.sh /mnt/vectorized/test.test.sh
 COPY docker/control/test.suite.sh /mnt/vectorized/test.suite.sh

--- a/docker/control/entrypoint.sh
+++ b/docker/control/entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+if [[ ! -r /mnt/vectorized/redpanda.deb ]]; then
+  echo 'error: unable to read /mnt/vectorized/redpanda.deb'
+  exit 1
+fi
+
+dpkg --force-confold -i /mnt/vectorized/redpanda.deb
+systemctl disable redpanda
+systemctl disable wasm_engine
+
 declare -A clients=( ["client1"]="")
 
 for (( i=1; i<=$WORKLOAD_CLUSTER_SIZE; i++ )); do  

--- a/docker/control/entrypoint.sh
+++ b/docker/control/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [[ ! -r /mnt/vectorized/redpanda.deb ]]; then
   echo 'error: unable to read /mnt/vectorized/redpanda.deb'
   exit 1

--- a/docker/docker-compose3.yaml
+++ b/docker/docker-compose3.yaml
@@ -1,6 +1,8 @@
 version: '3'
 services:
   redpanda1:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 3
@@ -13,7 +15,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda1/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda2:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 3
@@ -28,7 +33,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda2/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda3:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 3
@@ -43,7 +51,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda3/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   client1:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 3
@@ -60,7 +71,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/client1/mnt/vectorized/workloads/logs:/mnt/vectorized/workloads/logs
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   control:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 3
@@ -79,6 +93,7 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/control/mnt/vectorized/experiments:/mnt/vectorized/experiments
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
 networks:
   chaos:
     driver: bridge

--- a/docker/docker-compose6.2.yaml
+++ b/docker/docker-compose6.2.yaml
@@ -1,6 +1,8 @@
 version: '3'
 services:
   redpanda1:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -13,7 +15,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda1/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda2:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -28,7 +33,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda2/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda3:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -43,7 +51,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda3/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda4:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -58,7 +69,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda4/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda5:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -73,7 +87,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda5/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda6:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -88,7 +105,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda6/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   client1:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -108,7 +128,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/client1/mnt/vectorized/workloads/logs:/mnt/vectorized/workloads/logs
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   client2:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -128,7 +151,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/client2/mnt/vectorized/workloads/logs:/mnt/vectorized/workloads/logs
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   control:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -150,6 +176,7 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/control/mnt/vectorized/experiments:/mnt/vectorized/experiments
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
 networks:
   chaos:
     driver: bridge

--- a/docker/docker-compose6.yaml
+++ b/docker/docker-compose6.yaml
@@ -1,6 +1,8 @@
 version: '3'
 services:
   redpanda1:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -13,7 +15,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda1/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda2:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -28,7 +33,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda2/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda3:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -43,7 +51,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda3/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda4:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -58,7 +69,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda4/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda5:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -73,7 +87,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda5/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   redpanda6:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -88,7 +105,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/redpanda6/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   client1:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -108,7 +128,10 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/client1/mnt/vectorized/workloads/logs:/mnt/vectorized/workloads/logs
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
   control:
+    environment:
+      - DEB_PATH
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -130,6 +153,7 @@ services:
       - chaos
     volumes:
       - ./docker/bind_mounts/control/mnt/vectorized/experiments:/mnt/vectorized/experiments
+      - $DEB_PATH:/mnt/vectorized/redpanda.deb
 networks:
   chaos:
     driver: bridge

--- a/docker/rebuild3.sh
+++ b/docker/rebuild3.sh
@@ -14,8 +14,6 @@ docker-compose -f docker/docker-compose6.yaml --project-directory . rm -f || tru
 docker-compose -f docker/docker-compose3.yaml --project-directory . down --remove-orphans || true
 docker-compose -f docker/docker-compose3.yaml --project-directory . rm -f || true
 
-cp $DEB_PATH .
-
 if [ ! -f id_ed25519 ]; then
     ssh-keygen -t ed25519 -f id_ed25519 -N ""
 fi
@@ -35,4 +33,4 @@ mkdir -p ./docker/bind_mounts/client1/mnt/vectorized/workloads/logs
 
 chmod a+rw -R ./docker/bind_mounts
 
-docker-compose -f docker/docker-compose3.yaml --project-directory . build --build-arg REDPANDA_DEB=$(basename $DEB_PATH) --build-arg USER_ID=$(id -u $(whoami))
+docker-compose -f docker/docker-compose3.yaml --project-directory . build --build-arg USER_ID=$(id -u $(whoami))

--- a/docker/rebuild6.2.sh
+++ b/docker/rebuild6.2.sh
@@ -2,19 +2,12 @@
 
 set -e
 
-if [ "$DEB_PATH" == "" ]; then
-    echo "env var DEB_PATH must contain a path to redpanda deb file"
-    exit 1
-fi
-
 docker-compose -f docker/docker-compose6.2.yaml --project-directory . down --remove-orphans || true
 docker-compose -f docker/docker-compose6.2.yaml --project-directory . rm -f || true
 docker-compose -f docker/docker-compose6.yaml --project-directory . down --remove-orphans || true
 docker-compose -f docker/docker-compose6.yaml --project-directory . rm -f || true
 docker-compose -f docker/docker-compose3.yaml --project-directory . down --remove-orphans || true
 docker-compose -f docker/docker-compose3.yaml --project-directory . rm -f || true
-
-cp $DEB_PATH .
 
 if [ ! -f id_ed25519 ]; then
     ssh-keygen -t ed25519 -f id_ed25519 -N ""
@@ -42,4 +35,4 @@ mkdir -p ./docker/bind_mounts/client2/mnt/vectorized/workloads/logs
 
 chmod a+rw -R ./docker/bind_mounts
 
-docker-compose -f docker/docker-compose6.2.yaml --project-directory . build --build-arg REDPANDA_DEB=$(basename $DEB_PATH) --build-arg USER_ID=$(id -u $(whoami))
+docker-compose -f docker/docker-compose6.2.yaml --project-directory . build --build-arg USER_ID=$(id -u $(whoami))

--- a/docker/rebuild6.sh
+++ b/docker/rebuild6.sh
@@ -14,8 +14,6 @@ docker-compose -f docker/docker-compose6.yaml --project-directory . rm -f || tru
 docker-compose -f docker/docker-compose3.yaml --project-directory . down --remove-orphans || true
 docker-compose -f docker/docker-compose3.yaml --project-directory . rm -f || true
 
-cp $DEB_PATH .
-
 if [ ! -f id_ed25519 ]; then
     ssh-keygen -t ed25519 -f id_ed25519 -N ""
 fi
@@ -41,4 +39,4 @@ mkdir -p ./docker/bind_mounts/client1/mnt/vectorized/workloads/logs
 
 chmod a+rw -R ./docker/bind_mounts
 
-docker-compose -f docker/docker-compose6.yaml --project-directory . build --build-arg REDPANDA_DEB=$(basename $DEB_PATH) --build-arg USER_ID=$(id -u $(whoami))
+docker-compose -f docker/docker-compose6.yaml --project-directory . build --build-arg USER_ID=$(id -u $(whoami))

--- a/docker/redpanda/Dockerfile
+++ b/docker/redpanda/Dockerfile
@@ -12,9 +12,9 @@ RUN adduser --disabled-password --gecos "" ubuntu
 RUN usermod -aG sudo -u $USER_ID ubuntu
 RUN echo "ubuntu ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 RUN mkdir -p /home/ubuntu/.ssh
-COPY id_ed25519.pub /home/ubuntu/.ssh/authorized_keys
+COPY --chown=ubuntu:ubuntu id_ed25519.pub /home/ubuntu/.ssh/authorized_keys
 RUN mkdir -p /mnt/vectorized
-COPY control /mnt/vectorized/control
+COPY --chown=ubuntu:ubuntu control /mnt/vectorized/control
 RUN chown ubuntu:ubuntu -R /mnt/vectorized/control
 COPY docker/redpanda/entrypoint.sh /mnt/vectorized/entrypoint.sh
 COPY $REDPANDA_DEB /mnt/vectorized/$REDPANDA_DEB

--- a/docker/redpanda/Dockerfile
+++ b/docker/redpanda/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:20.04
 LABEL maintainer="Denis Rystsov <denis@vectorized.io>"
 ARG DEBIAN_FRONTEND=noninteractive
-ARG REDPANDA_DEB
 ARG USER_ID
 ARG REDPANDA_CLUSTER_SIZE
 ENV REDPANDA_CLUSTER_SIZE=${REDPANDA_CLUSTER_SIZE}
@@ -17,8 +16,4 @@ RUN mkdir -p /mnt/vectorized
 COPY --chown=ubuntu:ubuntu control /mnt/vectorized/control
 RUN chown ubuntu:ubuntu -R /mnt/vectorized/control
 COPY docker/redpanda/entrypoint.sh /mnt/vectorized/entrypoint.sh
-COPY $REDPANDA_DEB /mnt/vectorized/$REDPANDA_DEB
-RUN dpkg --force-confold -i /mnt/vectorized/$REDPANDA_DEB
-RUN systemctl disable redpanda
-RUN systemctl disable wasm_engine
 CMD /mnt/vectorized/entrypoint.sh

--- a/docker/redpanda/entrypoint.sh
+++ b/docker/redpanda/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 if [[ ! -r /mnt/vectorized/redpanda.deb ]]; then
   echo 'error: unable to read /mnt/vectorized/redpanda.deb'
   exit 1

--- a/docker/redpanda/entrypoint.sh
+++ b/docker/redpanda/entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+if [[ ! -r /mnt/vectorized/redpanda.deb ]]; then
+  echo 'error: unable to read /mnt/vectorized/redpanda.deb'
+  exit 1
+fi
+
+dpkg --force-confold -i /mnt/vectorized/redpanda.deb
+systemctl disable redpanda
+systemctl disable wasm_engine
+
 declare -A redpandas
 declare -A node_ids
 


### PR DESCRIPTION
This PR includes the changes in PR #3 

This PR refactors the way redpanda is installed in the docker containers. Instead of installing redpanda when the image is built, it is installed when the container is started via the `entrypoint.sh` script. Still expects the `DEB_PATH` environment variable as the path to the redpanda debian package outside of the container.

This change allows the docker image for chaos testing to not be strongly tied to a specific redpanda version.