### PR TITLE
Add new tx_compact workload

### DIFF
--- a/control/tx-compact.java.alive.sh
+++ b/control/tx-compact.java.alive.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -f /mnt/vectorized/workloads/logs/tx-compact.pid ]; then
+  echo "NO"
+  exit 0
+fi
+
+pid=$(cat /mnt/vectorized/workloads/logs/tx-compact.pid)
+
+if [ $pid == "" ]; then
+  echo "NO"
+  exit 0
+fi
+
+if process=$(ps -p $pid -o comm=); then
+  if [ $process == "java" ]; then
+    echo "YES"
+    exit 0
+  fi
+fi
+
+echo "NO"
+exit 0

--- a/control/tx-compact.java.start.sh
+++ b/control/tx-compact.java.start.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+cd /mnt/vectorized/workloads/logs
+nohup java -cp /mnt/vectorized/workloads/uber/target/uber-1.0-SNAPSHOT.jar:/mnt/vectorized/workloads/uber/target/dependency/* io.vectorized.tx_compact.App >/mnt/vectorized/workloads/logs/system.log 2>&1 &
+echo $! >/mnt/vectorized/workloads/logs/tx-compact.pid

--- a/control/tx-compact.java.stop.sh
+++ b/control/tx-compact.java.stop.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+if [ ! -f /mnt/vectorized/workloads/logs/tx-compact.pid ]; then
+  exit 0
+fi
+
+pid=$(cat /mnt/vectorized/workloads/logs/tx-compact.pid)
+
+if [ $pid == "" ]; then
+  exit 0
+fi
+
+if ps -p $pid; then
+  kill -9 $pid
+fi
+
+rm /mnt/vectorized/workloads/logs/tx-compact.pid

--- a/docker/test.all.sh
+++ b/docker/test.all.sh
@@ -20,6 +20,7 @@ if ! ./docker/ready6.sh; then
   ./docker/down6.sh
   exit 1
 fi
+./docker/test.suite.sh suites/test_suite_tx_compact.json
 ./docker/test.suite.sh suites/test_suite_tx_money.json
 ./docker/test.suite.sh suites/test_suite_tx_reads_writes.json
 ./docker/test.suite.sh suites/test_suite_rw_subscribe.json

--- a/harness/chaos/redpanda_static_cluster.py
+++ b/harness/chaos/redpanda_static_cluster.py
@@ -8,6 +8,7 @@ import traceback
 import random
 from chaos.types import TimeoutException
 from requests.exceptions import ConnectionError
+from requests.exceptions import ReadTimeout
 
 import logging
 logger = logging.getLogger("chaos")
@@ -315,6 +316,9 @@ class RedpandaCluster:
                 info = self._get_stable_details(nodes, topic, partition=partition, namespace=namespace, replication=replication)
                 if info == None:
                     sleep(1)
+            except ReadTimeout:
+                logger.debug("request timed out")
+                sleep(1)
             except:
                 e, v = sys.exc_info()[:2]
                 trace = traceback.format_exc()
@@ -340,7 +344,7 @@ class RedpandaCluster:
     
     def _get_details(self, node, namespace, topic, partition):
         ip = node.ip
-        r = requests.get(f"http://{ip}:9644/v1/partitions/{namespace}/{topic}/{partition}")
+        r = requests.get(f"http://{ip}:9644/v1/partitions/{namespace}/{topic}/{partition}", timeout=1)
         if r.status_code != 200:
             logger.error(f"status code: {r.status_code}")
             logger.error(f"content: {r.content}")

--- a/harness/chaos/workloads/all.py
+++ b/harness/chaos/workloads/all.py
@@ -4,6 +4,7 @@ from chaos.workloads.tx_single_reads_writes import tx_single_reads_writes
 from chaos.workloads.tx_money import tx_money
 from chaos.workloads.tx_subscribe import tx_subscribe
 from chaos.workloads.rw_subscribe import rw_subscribe
+from chaos.workloads.tx_compact import tx_compact
 
 import logging
 
@@ -57,13 +58,22 @@ def tx_subscribe_workload(nodes_path):
     writing_java.name = "tx-subscribe / java"
     return tx_subscribe.Workload(writing_java, nodes_path)
 
+def tx_compact_workload(nodes_path):
+    writing_java = tx_compact.Control()
+    writing_java.launch = "/mnt/vectorized/control/tx-compact.java.start.sh"
+    writing_java.alive = "/mnt/vectorized/control/tx-compact.java.alive.sh"
+    writing_java.kill = "/mnt/vectorized/control/tx-compact.java.stop.sh"
+    writing_java.name = "tx-compact / java"
+    return tx_compact.Workload(writing_java, nodes_path)
+
 WORKLOADS = {
     "tx-single-reads-writes / java": tx_single_reads_writes_workload,
     "reads-writes / java": reads_writes_workload,
     "rw-subscribe / java": rw_subscribe_workload,
     "list-offsets / java": list_offsets_workload,
     "tx-money / java": tx_money_workload,
-    "tx-subscribe / java": tx_subscribe_workload
+    "tx-subscribe / java": tx_subscribe_workload,
+    "tx-compact / java": tx_compact_workload,
 }
 
 def wait_all_workloads_killed(nodes_path):

--- a/harness/chaos/workloads/tx_compact/consistency.py
+++ b/harness/chaos/workloads/tx_compact/consistency.py
@@ -1,0 +1,228 @@
+from enum import Enum
+import sys
+import json
+from sh import mkdir, rm
+import traceback
+from confluent_kafka import Consumer, TopicPartition, OFFSET_BEGINNING
+from chaos.checks.result import Result
+from chaos.workloads.tx_compact.log_utils import State, cmds, transitions, phantoms
+import logging
+import os
+from collections import defaultdict
+from chaos.workloads.retryable_consumer import RetryableConsumer
+
+logger = logging.getLogger("consistency")
+
+class Write:
+    def __init__(self):
+        self.seq = -1
+        self.ltid= -1
+
+def validate(config, workload_dir):
+    logger.setLevel(logging.DEBUG)
+    logger_handler_path = os.path.join(workload_dir, "consistency.log")
+    handler = logging.FileHandler(logger_handler_path)
+    handler.setFormatter(logging.Formatter("%(asctime)s - %(message)s"))
+    logger.addHandler(handler)
+
+    has_errors = True
+    
+    try:
+        last_state = dict()
+        has_violation = False
+
+        inflight = defaultdict(lambda: [])
+        candidates = defaultdict(lambda: dict())
+        committed = defaultdict(lambda: dict())
+        last_offset = -1
+
+        with open(os.path.join(workload_dir, "workload.log"), "r") as workload_file:
+            for line in workload_file:
+                parts = line.rstrip().split('\t')
+
+                thread_id = int(parts[0])
+                if thread_id not in last_state:
+                    last_state[thread_id] = State.INIT
+
+                if parts[2] not in cmds:
+                    raise Exception(f"unknown cmd \"{parts[2]}\"")
+                new_state = cmds[parts[2]]
+
+                if new_state not in phantoms:
+                    if new_state not in transitions[last_state[thread_id]]:
+                        raise Exception(f"unknown transition {last_state[thread_id]} -> {new_state}")
+                    last_state[thread_id] = new_state
+
+                if new_state == State.STARTED:
+                    pass
+                elif new_state == State.CONSTRUCTING:
+                    pass
+                elif new_state == State.CONSTRUCTED:
+                    pass
+                elif new_state == State.ABORT:
+                    pass
+                elif new_state == State.SEEN:
+                    pass
+                elif new_state == State.ERROR:
+                    pass
+                elif new_state == State.EVENT:
+                    pass
+                elif new_state == State.TX:
+                    inflight[thread_id].clear()
+                elif new_state == State.LOG:
+                    if len(parts) < 4:
+                        continue
+                    if parts[3] != "put":
+                        continue
+                    key = parts[4]
+                    ltid = int(parts[5])
+                    seq = int(parts[6])
+                    if parts[7] == "a":
+                        continue
+                    inflight[thread_id].append([key, ltid, seq])
+                elif new_state == State.COMMIT:
+                    for [key, ltid, seq] in inflight[thread_id]:
+                        candidates[thread_id][key] = [ltid, seq]
+                elif new_state == State.OK:
+                    if thread_id not in inflight or len(inflight[thread_id])==0:
+                        # this is abort
+                        continue
+                    last_offset = max(last_offset, int(parts[3]))
+                    for [key, ltid, seq] in inflight[thread_id]:
+                        committed[thread_id][key] = [ltid, seq]
+                elif new_state == State.VIOLATION:
+                    parts = line.rstrip().split('\t', 3)
+                    msg = parts[3]
+                    has_violation = True
+                    logger.error(msg)
+                else:
+                    raise Exception(f"unknown state: {new_state}")
+        
+        if not has_violation:
+            RETRIES=5
+            c = RetryableConsumer(logger, config["brokers"])
+            c.init(config["topic"], RETRIES)
+
+            retries=RETRIES
+            read = dict()
+            writes = dict()
+
+            prev_offset = -1
+            is_active = True
+            while is_active:
+                if retries==0:
+                    raise Exception("Can't read from redpanda cluster")
+                msgs = c.consume()
+                retries-=1
+                for msg in msgs:
+                    if msg is None:
+                        continue
+                    if msg.error():
+                        logger.debug("Consumer error: {}".format(msg.error()))
+                        continue
+                    retries=RETRIES
+
+                    offset = msg.offset()
+
+                    if offset <= prev_offset:
+                        logger.error(f"offsets must increase; observed {offset} after {prev_offset}")
+                        has_violation = True
+                        break
+                    prev_offset = offset
+
+                    key = msg.key().decode('utf-8')
+                    value = msg.value().decode('utf-8')
+                    parts = value.split('\t')
+
+                    thread_id = int(parts[0])
+                    ltid = int(parts[1])
+                    seq = int(parts[2])
+                    if parts[3] == "a":
+                        logger.error(f"observed aborted tx: {key} {thread_id} {ltid} {seq}")
+                        has_violation = True
+                        break
+
+                    if thread_id in writes:
+                        write = writes[thread_id]
+                        if seq <= write.seq:
+                            if write.ltid != ltid:
+                                has_violation = True
+                                logger.error(f"time travel: {key} {thread_id} {ltid} {seq} @ {offset} vs seen {write.ltid}/{write.seq}")
+                                break
+                        write.seq = seq
+                        write.ltid = ltid
+                    else:
+                        writes[thread_id] = Write()
+                        writes[thread_id].seq = seq
+                        writes[thread_id].ltid = ltid
+
+                    read[key] = [thread_id, ltid, seq]
+
+                    if offset >= last_offset:
+                        is_active = False
+                        break
+            c.close()
+            if not has_violation:
+                for key in read.keys():
+                    [thread_id, ltid, seq] = read[key]
+
+                    if thread_id not in committed and thread_id not in candidates:
+                        has_violation = True
+                        logger.error(f"can't find thread {thread_id} in committed nor candidates")
+                        break
+
+                    known_key = False
+                    known_key = known_key or (thread_id in committed and key in committed[thread_id])
+                    known_key = known_key or (thread_id in candidates and key in candidates[thread_id])
+                    if not known_key:
+                        has_violation = True
+                        logger.error(f"can't find key {key} in committed nor candidates")
+                        break
+
+                    if thread_id in committed and key in committed[thread_id]:
+                        if committed[thread_id][key] == [ltid, seq]:
+                            continue
+
+                    if thread_id in candidates and key in candidates[thread_id]:
+                        if candidates[thread_id][key] == [ltid, seq]:
+                            continue
+                    
+                    logger.error(f"can't find read {key} {thread_id} {ltid} {seq} in attempted commits")
+
+                    logger.error(f"committed")
+                    for thread_id in committed.keys():
+                        for key in committed[thread_id].keys():
+                            [ltid, seq] = committed[thread_id][key]
+                            logger.error(f"\t{key} {thread_id} {ltid} {seq}")
+                    
+                    logger.error(f"candidates")
+                    for thread_id in candidates.keys():
+                        for key in candidates[thread_id].keys():
+                            [ltid, seq] = candidates[thread_id][key]
+                            logger.error(f"\t{key} {thread_id} {ltid} {seq}")
+
+                    has_violation = True
+                    break
+                pass
+
+        has_errors = has_violation
+
+        return {
+            "result": Result.FAILED if has_violation else Result.PASSED
+        }
+    except:
+        e, v = sys.exc_info()[:2]
+        trace = traceback.format_exc()
+        logger.debug(v)
+        logger.debug(trace)
+        
+        return {
+            "result": Result.UNKNOWN
+        }
+    finally:
+        handler.flush()
+        handler.close()
+        logger.removeHandler(handler)
+
+        if not has_errors:
+            rm("-rf", logger_handler_path)

--- a/harness/chaos/workloads/tx_compact/log_utils.py
+++ b/harness/chaos/workloads/tx_compact/log_utils.py
@@ -1,0 +1,46 @@
+from enum import Enum
+
+class State(Enum):
+    INIT = 0
+    STARTED = 1
+    CONSTRUCTING = 2
+    CONSTRUCTED = 3
+    TX = 4
+    COMMIT = 5
+    OK = 6
+    ERROR = 7
+    VIOLATION = 8
+    EVENT = 9
+    ABORT = 10
+    LOG = 11
+    SEEN = 12
+
+cmds = {
+    "started": State.STARTED,
+    "constructing": State.CONSTRUCTING,
+    "constructed": State.CONSTRUCTED,
+    "tx": State.TX,
+    "cmt": State.COMMIT,
+    "brt": State.ABORT,
+    "ok": State.OK,
+    "err": State.ERROR,
+    "event": State.EVENT,
+    "violation": State.VIOLATION,
+    "log": State.LOG,
+    "seen": State.SEEN
+}
+
+transitions = {
+    State.INIT: [State.STARTED],
+    State.STARTED: [State.CONSTRUCTING],
+    State.CONSTRUCTING: [State.CONSTRUCTED, State.ERROR],
+    State.CONSTRUCTED: [State.TX, State.CONSTRUCTING, State.SEEN],
+    State.SEEN: [State.CONSTRUCTING, State.SEEN],
+    State.TX: [State.ABORT, State.COMMIT, State.ERROR],
+    State.ABORT: [State.OK, State.ERROR],
+    State.COMMIT: [State.OK, State.ERROR],
+    State.OK: [State.TX, State.CONSTRUCTING],
+    State.ERROR: [State.TX, State.CONSTRUCTING]
+}
+
+phantoms = [ State.EVENT, State.VIOLATION, State.LOG ]

--- a/harness/chaos/workloads/tx_compact/stat.py
+++ b/harness/chaos/workloads/tx_compact/stat.py
@@ -1,0 +1,442 @@
+from sh import gnuplot, rm, cd
+import jinja2
+import sys
+import traceback
+import json
+import os
+from chaos.checks.result import Result
+from chaos.workloads.tx_compact.log_utils import State, cmds, transitions, phantoms
+import logging
+
+logger = logging.getLogger("stat")
+
+LATENCY = """
+set terminal png size 1600,1200
+set output "percentiles.png"
+set title "{{ title }}"
+set multiplot
+set yrange [0:{{ yrange }}]
+set xrange [-0.1:1.1]
+
+plot "percentiles.log" using 1:2 title "latency (us)" with line lt rgb "black",\\
+     {{p99}} title "p99" with lines lt 1
+
+unset multiplot
+"""
+
+AVAILABILITY = """
+set terminal png size 1600,1200
+set output "availability.png"
+set title "{{ title }}"
+show title
+plot "availability.log" using ($1/1000):2 title "unavailability (us)" w p ls 7
+"""
+
+OVERVIEW = """
+set terminal png size 1600,1200
+set output "overview.png"
+set multiplot
+set lmargin 6
+set rmargin 10
+
+set pointsize 0.2
+set yrange [0:{{ commit_boundary }}]
+set xrange [0:{{ duration }}]
+set size 1, 0.2
+set origin 0, 0
+
+set title "commit time"
+show title
+
+set parametric
+{% for fault in faults %}plot [t=0:{{ commit_boundary }}] {{ fault }}/1000,t notitle lt rgb "red"
+{% endfor %}{% for recovery in recoveries %}plot [t=0:{{ commit_boundary }}] {{ recovery }}/1000,t notitle lt rgb "blue"
+{% endfor %}unset parametric
+
+plot 'latency_commit.log' using ($1/1000):2 notitle with points lt rgb "black" pt 7,\\
+     {{commit_p99}} title "p99" with lines lt 1
+
+set notitle
+
+set y2range [0:{{ big_latency }}]
+set yrange [0:{{ big_latency }}]
+set size 1, 0.4
+set origin 0, 0.2
+unset ytics
+set y2tics auto
+set tmargin 0
+set border 11
+
+set parametric
+{% for fault in faults %}plot [t=0:{{ big_latency }}] {{ fault }}/1000,t notitle lt rgb "red"
+{% endfor %}{% for recovery in recoveries %}plot [t=0:{{ big_latency }}] {{ recovery }}/1000,t notitle lt rgb "blue"
+{% endfor %}unset parametric
+
+plot 'latency_ok.log' using ($1/1000):2 title "latency ok (us)" with points lt rgb "black" pt 7,\\
+     'latency_err.log' using ($1/1000):2 title "latency err (us)" with points lt rgb "red" pt 7,\\
+     'latency_timeout.log' using ($1/1000):2 title "latency timeout (us)" with points lt rgb "blue" pt 7,\\
+     {{p99}} title "p99" with lines lt 1
+
+set title "{{ title }}"
+show title
+
+set yrange [0:{{ throughput }}]
+
+set size 1, 0.4
+set origin 0, 0.6
+set format x ""
+set bmargin 0
+set tmargin 3
+set border 15
+unset y2tics
+set ytics
+
+set parametric
+{% for fault in faults %}plot [t=0:{{ throughput }}] {{ fault }}/1000,t notitle lt rgb "red"
+{% endfor %}{% for recovery in recoveries %}plot [t=0:{{ throughput }}] {{ recovery }}/1000,t notitle lt rgb "blue"
+{% endfor %}unset parametric
+
+plot 'throughput.log' using ($1/1000):2 title "throughput (1s)" with line lt rgb "black"
+
+unset multiplot
+"""
+
+class Throughput:
+    def __init__(self):
+        self.count = 0
+        self.time_us = 0
+
+def collect(config, workload_dir):
+    logger.setLevel(logging.DEBUG)
+    logger_handler_path = os.path.join(workload_dir, "stat.log")
+    handler = logging.FileHandler(logger_handler_path)
+    handler.setFormatter(logging.Formatter("%(asctime)s - %(message)s"))
+    logger.addHandler(handler)
+    
+    percentiles_log_path = os.path.join(workload_dir, "percentiles.log")
+    latency_commit_log_path = os.path.join(workload_dir, "latency_commit.log")
+    latency_ok_log_path = os.path.join(workload_dir, "latency_ok.log")
+    latency_err_log_path = os.path.join(workload_dir, "latency_err.log")
+    latency_timeout_log_path = os.path.join(workload_dir, "latency_timeout.log")
+    throughput_log_path = os.path.join(workload_dir, "throughput.log")
+    availability_log_path = os.path.join(workload_dir, "availability.log")
+
+    workload_log_path = os.path.join(workload_dir, "workload.log")
+
+    overview_gnuplot_path = os.path.join(workload_dir, "overview.gnuplot")
+    availability_gnuplot_path = os.path.join(workload_dir, "availability.gnuplot")
+    percentiles_gnuplot_path = os.path.join(workload_dir, "percentiles.gnuplot")
+
+    has_errors = True
+
+    try:
+        percentiles = open(percentiles_log_path, "w")
+        latency_ok = open(latency_ok_log_path, "w")
+        latency_err = open(latency_err_log_path, "w")
+        latency_timeout = open(latency_timeout_log_path, "w")
+        latency_commit = open(latency_commit_log_path, "w")
+        throughput_log = open(throughput_log_path, "w")
+        availability_log = open(availability_log_path, "w")
+
+        last_state = dict()
+        last_time = None
+
+        faults = []
+        recoveries = []
+
+        latency_ok_history = []
+        latency_err_history = []
+        latency_timeout_history = []
+        latency_commit_history = []
+        availability_history = []
+        throughput_history = []
+        throughput_bucket = None
+
+        should_measure = False
+        started = None
+
+        def tick(now, throughput_history):
+            while throughput_bucket.time_us + 1000000 < now:
+                if should_measure:
+                    ts = int((throughput_bucket.time_us-started+1000000)/1000)
+                    throughput_history.append([ts, throughput_bucket.count])
+                throughput_bucket.count = 0
+                throughput_bucket.time_us += 1000000
+
+        with open(workload_log_path, "r") as workload_file:
+            last_ok = None
+            attempt_starts = {}
+            commit_starts = {}
+            is_end_commit = {}
+
+            for line in workload_file:
+                parts = line.rstrip().split('\t')
+
+                thread_id = int(parts[0])
+                if thread_id not in last_state:
+                    last_state[thread_id] = State.INIT
+                if thread_id not in attempt_starts:
+                    attempt_starts[thread_id] = None
+
+                if parts[2] not in cmds:
+                    raise Exception(f"unknown cmd \"{parts[2]}\"")
+                new_state = cmds[parts[2]]
+
+                if new_state not in phantoms:
+                    if new_state not in transitions[last_state[thread_id]]:
+                        raise Exception(f"unknown transition {last_state[thread_id]} -> {new_state}")
+                    last_state[thread_id] = new_state
+
+                if new_state == State.STARTED:
+                    ts_us = None
+                    if last_time == None:
+                        ts_us = int(parts[1])
+                        throughput_bucket = Throughput()
+                        throughput_bucket.time_us = ts_us
+                    else:
+                        delta_us = int(parts[1])
+                        ts_us = last_time + delta_us
+                    last_time = ts_us
+                elif new_state == State.CONSTRUCTING:
+                    if last_time == None:
+                        raise Exception(f"last_time can't be None when processing: {new_state}")
+                    delta_us = int(parts[1])
+                    attempt_starts[thread_id] = last_time + delta_us
+                    tick(attempt_starts[thread_id], throughput_history)
+                    last_time = attempt_starts[thread_id]
+                elif new_state == State.CONSTRUCTED:
+                    if last_time == None:
+                        raise Exception(f"last_time can't be None when processing: {new_state}")
+                    delta_us = int(parts[1])
+                    end = last_time + delta_us
+                    tick(end, throughput_history)
+                    last_time = end
+                elif new_state == State.TX:
+                    if last_time == None:
+                        raise Exception(f"last_time can't be None when processing: {new_state}")
+                    delta_us = int(parts[1])
+                    attempt_starts[thread_id] = last_time + delta_us
+                    tick(attempt_starts[thread_id], throughput_history)
+                    last_time = attempt_starts[thread_id]
+                elif new_state == State.COMMIT or new_state == State.ABORT:
+                    if last_time == None:
+                        raise Exception(f"last_time can't be None when processing: {new_state}")
+                    delta_us = int(parts[1])
+                    end = last_time + delta_us
+                    tick(end, throughput_history)
+                    last_time = end
+                    if new_state == State.COMMIT:
+                        commit_starts[thread_id] = last_time
+                        is_end_commit[thread_id] = True
+                    if new_state == State.ABORT:
+                        is_end_commit[thread_id] = False
+                elif new_state == State.OK:
+                    if last_time == None:
+                        raise Exception(f"last_time can't be None when processing: {new_state}")
+                    delta_us = int(parts[1])
+                    end = last_time + delta_us
+                    tick(end, throughput_history)
+                    throughput_bucket.count+=1
+                    last_time = end
+                    if last_ok == None:
+                        last_ok = end
+                    if should_measure:
+                        if is_end_commit[thread_id]:
+                            availability_history.append([int((end-started)/1000), end-last_ok])
+                            latency_ok_history.append([int((end-started)/1000), end-attempt_starts[thread_id]])
+                            latency_commit_history.append([int((end-started)/1000), end-commit_starts[thread_id]])
+                            del commit_starts[thread_id]
+                        else:
+                            latency_err_history.append([int((end-started)/1000), end-attempt_starts[thread_id]])
+                    last_ok = end
+                    del is_end_commit[thread_id]
+                elif new_state == State.ERROR:
+                    if last_time == None:
+                        raise Exception(f"last_time can't be None when processing: {new_state}")
+                    delta_us = int(parts[1])
+                    end = last_time + delta_us
+                    tick(end, throughput_history)
+                    last_time = end
+                    if should_measure:
+                        latency_err_history.append([int((end-started)/1000), end-attempt_starts[thread_id]])
+                    if thread_id in is_end_commit:
+                        del is_end_commit[thread_id]
+                elif new_state == State.EVENT:
+                    ts_us = None
+                    if last_time == None:
+                        ts_us = int(parts[1])
+                        throughput_bucket = Throughput()
+                        throughput_bucket.time_us = ts_us
+                    else:
+                        delta_us = int(parts[1])
+                        ts_us = last_time + delta_us
+                    last_time = ts_us
+                    name = parts[3]
+                    if name == "measure" and not should_measure:
+                        should_measure = True
+                        started = ts_us
+                        last_ok = ts_us
+                    if should_measure:
+                        if name=="injecting" or name=="injected":
+                            faults.append(int((ts_us - started)/1000))
+                        elif name=="healing" or name=="healed":
+                            recoveries.append(int((ts_us - started)/1000))
+                elif new_state == State.SEEN:
+                    if last_time == None:
+                        raise Exception(f"last_time can't be None when processing: {new_state}")
+                    delta_us = int(parts[1])
+                    end = last_time + delta_us
+                    tick(end, throughput_history)
+                    last_time = end
+                elif new_state == State.VIOLATION or new_state == State.LOG:
+                    if last_time == None:
+                        raise Exception(f"last_time can't be None when processing: {new_state}")
+                    delta_us = int(parts[1])
+                    end = last_time + delta_us
+                    tick(end, throughput_history)
+                    last_time = end
+                else:
+                    raise Exception(f"unknown state: {new_state}")
+        
+        if not(should_measure):
+            return {
+                "result": Result.NODATA
+            }
+
+        duration_ms = 0
+        max_latency_us = 0
+        min_latency_us = None
+        max_throughput = 0
+        max_unavailability_us = 0
+        ops = len(latency_ok_history)
+
+        latencies = []
+        for [_, latency_us] in latency_ok_history:
+            latencies.append(latency_us)
+        latencies.sort()
+        p99  = latencies[int(0.99*len(latencies))]
+        for i in range(0,len(latencies)):
+            percentiles.write(f"{float(i) / len(latencies)}\t{latencies[i]}\n")
+
+        latencies = []
+        for [_, latency_us] in latency_commit_history:
+            latencies.append(latency_us)
+        latencies.sort()
+        commit_p99 = latencies[int(0.99*len(latencies))]
+        commit_min = latencies[0]
+        commit_max = latencies[-1]
+        
+        for [ts_ms,latency_us] in latency_commit_history:
+            duration_ms = max(duration_ms, ts_ms)
+            latency_commit.write(f"{ts_ms}\t{latency_us}\n")
+
+        for [ts_ms,latency_us] in latency_ok_history:
+            duration_ms = max(duration_ms, ts_ms)
+            if min_latency_us == None:
+                min_latency_us = latency_us
+            min_latency_us = min(min_latency_us, latency_us)
+            max_latency_us = max(max_latency_us, latency_us)
+            latency_ok.write(f"{ts_ms}\t{latency_us}\n")
+
+        for [ts_ms,latency_us] in latency_err_history:
+            duration_ms = max(duration_ms, ts_ms)
+            max_latency_us = max(max_latency_us, latency_us)
+            latency_err.write(f"{ts_ms}\t{latency_us}\n")
+
+        for [ts_ms,latency_us] in latency_timeout_history:
+            duration_ms = max(duration_ms, ts_ms)
+            max_latency_us = max(max_latency_us, latency_us)
+            latency_timeout.write(f"{ts_ms}\t{latency_us}\n")
+
+        for [ts_ms,latency_us] in availability_history:
+            max_unavailability_us = max(max_unavailability_us, latency_us)
+            availability_log.write(f"{ts_ms}\t{latency_us}\n")
+
+        for [ts_ms, count] in throughput_history:
+            duration_ms = max(duration_ms, ts_ms)
+            max_throughput = max(max_throughput, count)
+            throughput_log.write(f"{ts_ms}\t{count}\n")
+
+        latency_ok.close()
+        latency_err.close()
+        latency_timeout.close()
+        latency_commit.close()
+        throughput_log.close()
+        availability_log.close()
+
+        with open(overview_gnuplot_path, "w") as gnuplot_file:
+            gnuplot_file.write(
+                jinja2.Template(OVERVIEW).render(
+                    title = config["name"],
+                    duration=int(duration_ms/1000),
+                    big_latency=int(p99*1.2),
+                    p99=p99,
+                    commit_p99=commit_p99,
+                    commit_boundary=int(commit_p99*1.2), 
+                    faults = faults,
+                    recoveries = recoveries,
+                    throughput=int(max_throughput*1.2)))
+
+        with open(availability_gnuplot_path, "w") as gnuplot_file:
+            gnuplot_file.write(jinja2.Template(AVAILABILITY).render(
+                title = config["name"]))
+
+        with open(percentiles_gnuplot_path, "w") as latency_file:
+            latency_file.write(jinja2.Template(LATENCY).render(
+                title = config["name"],
+                yrange = int(p99*1.2),
+                p99 = p99))
+
+        gnuplot(overview_gnuplot_path, _cwd=workload_dir)
+        gnuplot(availability_gnuplot_path, _cwd=workload_dir)
+        gnuplot(percentiles_gnuplot_path, _cwd=workload_dir)
+
+        has_errors = False
+
+        return {
+            "result": Result.PASSED,
+            "latency_us": {
+                "tx": {
+                    "min": min_latency_us,
+                    "max": max_latency_us,
+                    "p99": p99
+                },
+                "commit": {
+                    "min": commit_min,
+                    "max": commit_max,
+                    "p99": commit_p99
+                }
+            },
+            "max_unavailability_us": max_unavailability_us,
+            "throughput": {
+                "avg/s": int(float(1000 * ops) / duration_ms),
+                "max/s": max_throughput
+            }
+        }
+    except:
+        e, v = sys.exc_info()[:2]
+        trace = traceback.format_exc()
+        logger.debug(v)
+        logger.debug(trace)
+
+        return {
+            "result": Result.UNKNOWN
+        }
+    finally:
+        handler.flush()
+        handler.close()
+        logger.removeHandler(handler)
+
+        if not has_errors:
+            rm("-rf", logger_handler_path)
+
+        rm("-rf", percentiles_log_path)
+        rm("-rf", latency_ok_log_path)
+        rm("-rf", latency_err_log_path)
+        rm("-rf", latency_timeout_log_path)
+        rm("-rf", throughput_log_path)
+        rm("-rf", availability_log_path)
+        rm("-rf", overview_gnuplot_path)
+        rm("-rf", availability_gnuplot_path)
+        rm("-rf", percentiles_gnuplot_path)
+        rm("-rf", latency_commit_log_path)

--- a/harness/chaos/workloads/tx_compact/tx_compact.py
+++ b/harness/chaos/workloads/tx_compact/tx_compact.py
@@ -1,0 +1,221 @@
+from sh import ssh
+from sh import cd
+from sh import mkdir
+from sh import python3
+import json
+import requests
+import os
+import sys
+import traceback
+import time
+from time import sleep
+from chaos.redpanda_static_cluster import RedpandaNode
+from chaos.types import TimeoutException
+from chaos.checks.result import Result
+from chaos.workloads.tx_compact import consistency
+from chaos.workloads.tx_compact import stat
+
+import logging
+logger = logging.getLogger("chaos")
+
+class Info:
+    def __init__(self):
+        self.succeeded_ops = 0
+        self.failed_ops = 0
+        self.timedout_ops = 0
+        self.is_active = 0
+
+class Control:
+    def __init__(self):
+        self.launch = None
+        self.kill = None
+        self.alive = None
+        self.name = None
+
+class Workload:
+    def __init__(self, scripts, nodes_path):
+        self.scripts = scripts
+        self.nodes = []
+        self.name = scripts.name
+        with open(nodes_path, "r") as f:
+            for line in f:
+                line = line.rstrip()
+                parts = line.split(" ")
+                self.nodes.append(RedpandaNode(parts[0], int(parts[1])))
+    
+    def heal(self):
+        for node in self.nodes:
+            ssh("ubuntu@" + node.ip, "/mnt/vectorized/control/network.heal.all.sh")
+    
+    def is_alive(self, node):
+        ip = node.ip
+        result = ssh("ubuntu@"+ip, self.scripts.alive)
+        return "YES" in result
+    
+    def launch(self, node):
+        ip = node.ip
+        ssh("ubuntu@"+ip, self.scripts.launch)
+    
+    def kill(self, node):
+        ip = node.ip
+        ssh("ubuntu@"+ip, self.scripts.kill)
+    
+    def kill_everywhere(self):
+        for node in self.nodes:
+            logger.debug(f"killing workload process on node {node.ip}")
+            self.kill(node)
+    
+    def stop_everywhere(self):
+        for node in self.nodes:
+            logger.debug(f"stopping workload on node {node.ip}")
+            self.stop(node)
+    
+    def wait_killed(self, timeout_s=10):
+        begin = time.time()
+        for node in self.nodes:
+            while True:
+                if time.time() - begin > timeout_s:
+                    raise TimeoutException(f"workload stuck and can't be killed in {timeout_s} sec")
+                logger.debug(f"checking if workload process is alive {node.ip}")
+                if not self.is_alive(node):
+                    break
+                sleep(1)
+    
+    def launch_everywhere(self):
+        for node in self.nodes:
+            logger.debug(f"starting workload on node {node.ip}")
+            self.launch(node)
+
+    def wait_alive(self, timeout_s=10):
+        begin = time.time()
+        for node in self.nodes:
+            while True:
+                if time.time() - begin > timeout_s:
+                    raise TimeoutException(f"workload process isn't running within {timeout_s} sec")
+                logger.debug(f"checking if workload process is running on {node.ip}")
+                if self.is_alive(node):
+                    break
+                sleep(1)
+    
+    def wait_ready(self, timeout_s=10):
+        begin = time.time()
+        for node in self.nodes:
+            while True:
+                if time.time() - begin > timeout_s:
+                    raise TimeoutException(f"workload process isn't ready to accept requests within {timeout_s} sec")
+                try:
+                    logger.debug(f"checking if workload http api is ready on {node.ip}")
+                    self.ping(node)
+                    break
+                except:
+                    if not self.is_alive(node):
+                        logger.error(f"workload process on {node.ip} (id={node.id}) died")
+                        raise
+    
+    def wait_progress(self, timeout_s=10):
+        begin = time.time()
+        started = dict()
+        for node in self.nodes:
+            started[node.ip]=self.info(node, timeout_s=timeout_s)
+        made_progress = False
+        progressed = dict()
+        while True:
+            made_progress = True
+            for node in self.nodes:
+                if time.time() - begin > timeout_s:
+                    raise TimeoutException(f"workload haven't done progress within {timeout_s} sec")
+                if node.ip in progressed:
+                    continue
+                logger.debug(f"checking if node {node.ip} made progress")
+                info = self.info(node, timeout_s=timeout_s)
+                if info.succeeded_ops > started[node.ip].succeeded_ops:
+                    progressed[node.id]=True
+                else:
+                    made_progress = False
+            if made_progress:
+                break
+            sleep(1)
+
+    def emit_event(self, node, name):
+        ip = node.ip
+        r = requests.post(f"http://{ip}:8080/event/" + name)
+        if r.status_code != 200:
+            raise Exception(f"unexpected status code: {r.status_code}")
+
+    def init(self, node, server, brokers, topic, experiment, settings, timeout_s=10):
+        ip = node.ip
+        r = requests.post(f"http://{ip}:8080/init", json={
+            "experiment": experiment,
+            "server": server,
+            "topic": topic,
+            "brokers": brokers,
+            "settings": settings}, timeout=timeout_s)
+        if r.status_code != 200:
+            raise Exception(f"unexpected status code: {r.status_code}")
+    
+    def start(self, node, timeout_s=10):
+        ip = node.ip
+        r = requests.post(f"http://{ip}:8080/start", timeout=timeout_s)
+        if r.status_code != 200:
+            raise Exception(f"unexpected status code: {r.status_code}")
+
+    def stop(self, node, timeout_s=10):
+        ip = node.ip
+        r = requests.post(f"http://{ip}:8080/stop", timeout=timeout_s)
+        if r.status_code != 200:
+            raise Exception(f"unexpected status code: {r.status_code}")
+
+    def info(self, node, timeout_s=10):
+        ip = node.ip
+        r = requests.get(f"http://{ip}:8080/info", timeout=timeout_s)
+        if r.status_code != 200:
+            raise Exception(f"unexpected status code: {r.status_code}")
+        info = Info()
+        info.succeeded_ops = r.json()["succeeded_ops"]
+        info.failed_ops = r.json()["failed_ops"]
+        info.timedout_ops = r.json()["timedout_ops"]
+        info.is_active = r.json()["is_active"]
+        return info
+    
+    def ping(self, node, timeout_s=10):
+        ip = node.ip
+        r = requests.get(f"http://{ip}:8080/ping", timeout=timeout_s)
+        if r.status_code != 200:
+            raise Exception(f"unexpected status code: {r.status_code}")
+
+    def analyze(self, config):
+        logger.debug(f"analyzing {config['experiment_id']}")
+
+        for check in config["workload"]["checks"]:
+            if check["name"] == "consistency":
+                check["result"] = Result.PASSED
+                for node in self.nodes:
+                    workload_dir = f"/mnt/vectorized/experiments/{config['experiment_id']}/{node.ip}"
+                    if os.path.isdir(workload_dir):
+                        check[node.ip] = consistency.validate(config, workload_dir)
+                    else:
+                        check[node.ip] = {
+                            "result": Result.UNKNOWN,
+                            "message": f"Can't find logs dir: {workload_dir}"
+                        }
+                    check["result"] = Result.more_severe(check["result"], check[node.ip]["result"])
+                config["result"] = Result.more_severe(config["result"], check["result"])
+            elif check["name"] == "stat":
+                check["result"] = Result.PASSED
+                for node in self.nodes:
+                    workload_dir = f"/mnt/vectorized/experiments/{config['experiment_id']}/{node.ip}"
+                    if os.path.isdir(workload_dir):
+                        check[node.ip] = stat.collect(config, workload_dir)
+                    else:
+                        check[node.ip] = {
+                            "result": Result.UNKNOWN,
+                            "message": f"Can't find logs dir: {workload_dir}"
+                        }
+                    check["result"] = Result.more_severe(check["result"], check[node.ip]["result"])
+                config["result"] = Result.more_severe(config["result"], check["result"])
+            else:
+                check["result"] = Result.UNKNOWN
+                check["message"] = "Unknown check"
+                config["result"] = Result.more_severe(config["result"], check["result"])
+        
+        return config

--- a/harness/check_tx_compact.py
+++ b/harness/check_tx_compact.py
@@ -1,0 +1,23 @@
+import sys
+import os.path
+import json
+from chaos.workloads.tx_compact import consistency
+from chaos.workloads.tx_compact import stat
+
+check_type = sys.argv[1]
+config_filename = sys.argv[2]
+workload_dir = sys.argv[3]
+
+config = None
+with open(config_filename, "r") as config_file:
+    config = json.load(config_file)
+
+if check_type == "consistency":
+    result = consistency.validate(config, workload_dir)
+    with open(os.path.join(workload_dir, "consistency.json"), "w") as consistency_file:
+        consistency_file.write(json.dumps(result))
+elif check_type == "stat":
+    result = stat.collect(config, workload_dir)
+    print(json.dumps(result, indent=2))
+else:
+    raise Exception(f"unknown check type: {check_type}")

--- a/harness/test.test.py
+++ b/harness/test.test.py
@@ -79,3 +79,6 @@ for i in range(0, args.repeat):
         info.write(json.dumps(results, indent=2))
     with open(f"/mnt/vectorized/experiments/latest.json", "w") as info:
         info.write(json.dumps(results, indent=2))
+    
+    if results["test_runs"][test["name"]][experiment_id] == "FAILED":
+        break

--- a/suites/test_suite_tx_compact.json
+++ b/suites/test_suite_tx_compact.json
@@ -1,0 +1,42 @@
+{
+    "name": "all",
+    "tests": [
+        "tx_compact/baseline.json",
+        "tx_compact/hijack_tx_ids.json",
+        "tx_compact/isolate_data_follower.json",
+        "tx_compact/isolate_data_leader.json",
+        "tx_compact/isolate_tx_all.json",
+        "tx_compact/isolate_tx_follower.json",
+        "tx_compact/isolate_tx_leader.json",
+        "tx_compact/kill_data_follower.json",
+        "tx_compact/kill_data_leader.json",
+        "tx_compact/kill_tx_follower.json",
+        "tx_compact/kill_tx_leader.json",
+        "tx_compact/pause_data_leader.json",
+        "tx_compact/pause_tx_leader.json",
+        "tx_compact/reconfigure_313_data.json",
+        "tx_compact/reconfigure_313_tx.json",
+        "tx_compact/transfer_data_leadership.json",
+        "tx_compact/transfer_tx_leadership.json",
+        "tx_compact/recycle_all.json"
+    ],
+    "settings": {
+        "test": {
+            "redpanda": {
+                "redpanda.compacted_log_segment_size": 1048577,
+                "redpanda.log_cleanup_policy": "compact",
+                "redpanda.log_segment_size": 1048577
+            },
+            "cleanup": "compact",
+            "remove_logs_on_success": false,
+            "log-level": {
+                "default": "info"
+            }
+        },
+        "suite": {
+            "should_retry_on_transient_errors": true,
+            "retries": 4,
+            "retried_tests": 2
+        }
+    }
+}

--- a/suites/tests/tx_compact/baseline.json
+++ b/suites/tests/tx_compact/baseline.json
@@ -1,0 +1,22 @@
+{
+    "name": "tx-compact / java / baseline",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": null,
+    "checks": [
+        { "name": "redpanda_process_liveness" }
+    ]
+}

--- a/suites/tests/tx_compact/hijack_tx_ids.json
+++ b/suites/tests/tx_compact/hijack_tx_ids.json
@@ -1,0 +1,25 @@
+{
+    "name": "tx-compact / java / hijack tx ids",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "hijack_tx_ids",
+        "ids": [ "tx-0", "tx-1" ]
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" }
+    ]
+}

--- a/suites/tests/tx_compact/isolate_data_follower.json
+++ b/suites/tests/tx_compact/isolate_data_follower.json
@@ -1,0 +1,27 @@
+{
+    "name": "tx-compact / java / isolate data follower",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "isolate_follower",
+        "topic": "topic1",
+        "alias": "isolate_data_follower"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/isolate_data_leader.json
+++ b/suites/tests/tx_compact/isolate_data_leader.json
@@ -1,0 +1,27 @@
+{
+    "name": "tx-compact / java / isolate data leader",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "isolate_leader",
+        "topic": "topic1",
+        "alias": "isolate_data_leader"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/isolate_tx_all.json
+++ b/suites/tests/tx_compact/isolate_tx_all.json
@@ -1,0 +1,22 @@
+{
+    "name": "tx-compact / java / isolate tx coordinator",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": "isolate_tx_all",
+    "checks": [
+        { "name": "redpanda_process_liveness" }
+    ]
+}

--- a/suites/tests/tx_compact/isolate_tx_follower.json
+++ b/suites/tests/tx_compact/isolate_tx_follower.json
@@ -1,0 +1,23 @@
+{
+    "name": "tx-compact / java / isolate tx follower",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": "isolate_tx_follower",
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/isolate_tx_leader.json
+++ b/suites/tests/tx_compact/isolate_tx_leader.json
@@ -1,0 +1,29 @@
+{
+    "name": "tx-compact / java / isolate tx leader",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "isolate_leader",
+        "topic": "tx",
+        "namespace": "kafka_internal",
+        "partition": 0,
+        "alias": "isolate_tx_leader"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/kill_data_follower.json
+++ b/suites/tests/tx_compact/kill_data_follower.json
@@ -1,0 +1,26 @@
+{
+    "name": "tx-compact / java / kill data follower",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "kill_follower",
+        "alias": "kill_data_follower"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/kill_data_leader.json
+++ b/suites/tests/tx_compact/kill_data_leader.json
@@ -1,0 +1,26 @@
+{
+    "name": "tx-compact / java / kill data leader",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "kill_leader",
+        "alias": "kill_data_leader"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/kill_tx_follower.json
+++ b/suites/tests/tx_compact/kill_tx_follower.json
@@ -1,0 +1,29 @@
+{
+    "name": "tx-compact / java / kill tx follower",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "kill_follower",
+        "topic": "tx",
+        "namespace": "kafka_internal",
+        "partition": 0,
+        "alias": "kill_tx_follower"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/kill_tx_leader.json
+++ b/suites/tests/tx_compact/kill_tx_leader.json
@@ -1,0 +1,29 @@
+{
+    "name": "tx-compact / java / kill tx leader",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "kill_leader",
+        "topic": "tx",
+        "namespace": "kafka_internal",
+        "partition": 0,
+        "alias": "kill_tx_leader"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/pause_data_leader.json
+++ b/suites/tests/tx_compact/pause_data_leader.json
@@ -1,0 +1,27 @@
+{
+    "name": "tx-compact / java / pause data leader",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "pause_leader",
+        "topic": "topic1",
+        "alias": "pause_data_leader"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/pause_tx_leader.json
+++ b/suites/tests/tx_compact/pause_tx_leader.json
@@ -1,0 +1,29 @@
+{
+    "name": "tx-compact / java / pause tx leader",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "pause_leader",
+        "topic": "tx",
+        "namespace": "kafka_internal",
+        "partition": 0,
+        "alias": "pause_tx_leader"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/reconfigure_313_data.json
+++ b/suites/tests/tx_compact/reconfigure_313_data.json
@@ -1,0 +1,28 @@
+{
+    "name": "tx-compact / java / reconfigure 3->1->3 data",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "reconfigure_313",
+        "timeout_s": 60,
+        "topic": "topic1",
+        "alias": "reconfigure_313_data"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/reconfigure_313_tx.json
+++ b/suites/tests/tx_compact/reconfigure_313_tx.json
@@ -1,0 +1,30 @@
+{
+    "name": "tx-compact / java / reconfigure 3->1->3 tx",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "reconfigure_313",
+        "timeout_s": 60,
+        "topic": "tx",
+        "namespace": "kafka_internal",
+        "partition": 0,
+        "alias": "reconfigure_313_tx"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" },
+        { "name": "progress_during_fault", "min-delta": 100 }
+    ]
+}

--- a/suites/tests/tx_compact/recycle_all.json
+++ b/suites/tests/tx_compact/recycle_all.json
@@ -1,0 +1,22 @@
+{
+    "name": "tx-compact / java / recycle all",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": "recycle_all",
+    "checks": [
+        { "name": "redpanda_process_liveness" }
+    ]
+}

--- a/suites/tests/tx_compact/transfer_data_leadership.json
+++ b/suites/tests/tx_compact/transfer_data_leadership.json
@@ -1,0 +1,26 @@
+{
+    "name": "tx-compact / java / transfer data leadership",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "leadership_transfer",
+        "topic": "topic1",
+        "alias": "transfer_data_leadership"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" }
+    ]
+}

--- a/suites/tests/tx_compact/transfer_tx_leadership.json
+++ b/suites/tests/tx_compact/transfer_tx_leadership.json
@@ -1,0 +1,28 @@
+{
+    "name": "tx-compact / java / transfer tx leadership",
+    "scenario": "tx_single_table_single_fault",
+    "topic": "topic1",
+    "replication": 3,
+    "workload": {
+        "name": "tx-compact / java",
+        "checks": [
+            { "name": "consistency" },
+            { "name": "stat" }
+        ],
+        "settings": {
+            "writers": 2,
+            "edge_readers": 2,
+            "hist_readers": 2
+        }
+    },
+    "fault": {
+        "name": "leadership_transfer",
+        "topic": "tx",
+        "namespace": "kafka_internal",
+        "partition": 0,
+        "alias": "transfer_tx_leadership"
+    },
+    "checks": [
+        { "name": "redpanda_process_liveness" }
+    ]
+}

--- a/workloads/uber/src/main/java/io/vectorized/tx_compact/App.java
+++ b/workloads/uber/src/main/java/io/vectorized/tx_compact/App.java
@@ -1,0 +1,150 @@
+package io.vectorized.tx_compact;
+
+import com.google.gson.Gson;
+import java.io.*;
+import java.util.HashMap;
+
+import static spark.Spark.*;
+import spark.*;
+
+// java -cp $(pwd)/target/uber-1.0-SNAPSHOT.jar:$(pwd)/target/dependency/* io.vectorized.tx_compact.App
+public class App
+{
+    public static class WorkflowSettings {
+        public int writers = 1;
+        public int edge_readers = 1;
+        public int hist_readers = 1;
+    }
+    
+    public static class InitBody {
+        public String experiment;
+        public String server;
+        public String brokers;
+        public String topic;
+        public WorkflowSettings settings;
+    }
+
+    public static class OpsInfo {
+        public long succeeded_ops = 0;
+        public long failed_ops = 0;
+        public long timedout_ops = 0;
+
+        public OpsInfo copy() {
+            var value = new OpsInfo();
+            value.succeeded_ops = succeeded_ops;
+            value.failed_ops = failed_ops;
+            value.timedout_ops = timedout_ops;
+            return value;
+        }
+    }
+
+    public static class Info extends OpsInfo {
+        public boolean is_active;
+        public HashMap<String, OpsInfo> threads = new HashMap<>();
+    }
+
+    static enum State {
+        FRESH,
+        INITIALIZED,
+        STARTED,
+        STOPPED
+    }
+
+    public class JsonTransformer implements ResponseTransformer {
+        private Gson gson = new Gson();
+    
+        @Override
+        public String render(Object model) {
+            return gson.toJson(model);
+        }
+    }
+
+    State state = State.FRESH;
+    
+    InitBody params = null;
+    Workload workload = null;
+
+    void run() throws Exception {
+        port(8080);
+
+        get("/ping", (req, res) -> {
+            res.status(200);
+            return "";
+        });
+
+        get("/info", "application/json", (req, res) -> {
+            var info = new Info();
+            info.is_active = false;
+            info.failed_ops = 0;
+            info.succeeded_ops = 0;
+            info.timedout_ops = 0;
+            if (workload != null) {
+                info.is_active = workload.is_active;
+                info.threads = workload.get_ops_info();
+                for (String key : info.threads.keySet()) {
+                    var value = info.threads.get(key);
+                    info.succeeded_ops += value.succeeded_ops;
+                    info.failed_ops += value.failed_ops;
+                    info.timedout_ops += value.timedout_ops;
+                }
+            }
+            return info;
+        }, new JsonTransformer());
+
+        post("/init", (req, res) -> {
+            if (state != State.FRESH) {
+                throw new Exception("Unexpected state: " + state);
+            }
+            state = State.INITIALIZED;
+
+            Gson gson = new Gson();
+            
+            params = gson.fromJson(req.body(), InitBody.class);
+            File root = new File(params.experiment);
+
+            if (!root.mkdir()) {
+                throw new Exception("Can't create folder: " + params.experiment);
+            }
+            
+            res.status(200);
+            return "";
+        });
+
+        post("/event/:name", (req, res) -> {
+            var name = req.params(":name");
+            workload.event(name);
+            res.status(200);
+            return "";
+        });
+        
+        post("/start", (req, res) -> {
+            if (state != State.INITIALIZED) {
+                throw new Exception("Unexpected state: " + state);
+            }
+            state = State.STARTED;
+
+            workload = new Workload(params);
+            workload.start();
+            
+            //curl -X POST http://127.0.0.1:8080/start -H 'Content-Type: application/json' -d '{"topic":"topic1","brokers":"127.0.0.1:9092"}'
+            res.status(200);
+            return "";
+        });
+
+        post("/stop", (req, res) -> {
+            if (state != State.STARTED) {
+                throw new Exception("Unexpected state: " + state);
+            }
+            state = State.STOPPED;
+            workload.stop();
+            //curl -X POST http://127.0.0.1:8080/start -H 'Content-Type: application/json' -d '{"topic":"topic1","brokers":"127.0.0.1:9092"}'
+            res.status(200);
+            return "";
+        });
+    }
+
+    public static void main( String[] args ) throws Exception
+    {
+        new App().run();
+    }
+}

--- a/workloads/uber/src/main/java/io/vectorized/tx_compact/Workload.java
+++ b/workloads/uber/src/main/java/io/vectorized/tx_compact/Workload.java
@@ -1,0 +1,591 @@
+package io.vectorized.tx_compact;
+import java.io.*;
+import java.util.Properties;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import java.lang.Thread;
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Collections;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import java.time.Duration;
+import java.util.Random;
+import java.util.concurrent.Future;
+
+import java.nio.charset.Charset;
+
+public class Workload {
+    public volatile boolean is_active = false;
+
+    private volatile App.InitBody args;
+    private BufferedWriter opslog;
+    private volatile Random random = new Random();
+
+    private HashMap<Integer, App.OpsInfo> ops_info;
+    private synchronized void succeeded(int thread_id) {
+        ops_info.get(thread_id).succeeded_ops += 1;
+    }
+    private synchronized void failed(int thread_id) {
+        ops_info.get(thread_id).failed_ops += 1;
+    }
+
+    private volatile long last_offset = -1;
+
+    private long last_error_id = 0;
+    private synchronized long get_error_id() {
+        return ++this.last_error_id;
+    }
+
+    private long past_us;
+    private synchronized void log(int thread_id, String message) throws Exception {
+        var now_us = System.nanoTime() / 1000;
+        if (now_us < past_us) {
+            throw new Exception("Time cant go back, observed: " + now_us + " after: " + past_us);
+        }
+        opslog.write("" + thread_id +
+                        "\t" + (now_us - past_us) +
+                        "\t" + message + "\n");
+        past_us = now_us;
+    }
+    private synchronized void violation(int thread_id, String message) throws Exception {
+        var now_us = System.nanoTime() / 1000;
+        if (now_us < past_us) {
+            throw new Exception("Time cant go back, observed: " + now_us + " after: " + past_us);
+        }
+        opslog.write("" + thread_id +
+                        "\t" + (now_us - past_us) +
+                        "\tviolation" +
+                        "\t" + message + "\n");
+        opslog.flush();
+        opslog.close();
+        System.exit(1);
+        past_us = now_us;
+    }
+    public void event(String name) throws Exception {
+        log(-1, "event\t" + name);
+    }
+
+    private volatile ArrayList<Thread> producers;
+    private volatile ArrayList<Thread> edge_consumers;
+    private volatile ArrayList<Thread> hist_consumers;
+    
+    private HashMap<Integer, Integer> last_committed_seq;
+    private HashMap<Integer, Integer> committing_ltid;
+    private static final String randAlpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    private static final int alphaLen = randAlpha.length();
+
+    public Workload(App.InitBody args) {
+        this.args = args;
+    }
+
+    private String randomString(Random random, int length) {
+        StringBuffer buf = new StringBuffer();
+        buf.append('~');
+        for (int i=0;i<length-1;i++) {
+            buf.append(randAlpha.charAt(random.nextInt(alphaLen)));
+        }
+        return buf.toString();
+    }
+
+    public void start() throws Exception {
+        File root = new File(args.experiment, args.server);
+
+        if (!root.mkdir()) {
+            throw new Exception("Can't create folder: " + root);
+        }
+
+        is_active = true;
+        past_us = 0;
+        opslog = new BufferedWriter(new FileWriter(new File(new File(args.experiment, args.server), "workload.log")));
+        
+        ops_info = new HashMap<>();
+        
+        int thread_id=0;
+        producers = new ArrayList<>();
+        edge_consumers = new ArrayList<>();
+        hist_consumers = new ArrayList<>();
+        last_committed_seq = new HashMap<>();
+        committing_ltid = new HashMap<>();
+        for (int i=0;i<this.args.settings.writers;i++) {
+            final var j=thread_id++;
+            ops_info.put(j, new App.OpsInfo());
+            producers.add(new Thread(() -> { 
+                try {
+                    writeProcess(j);
+                } catch(Exception e) {
+                    synchronized(this) {
+                        System.out.println("=== err on writeProcess");
+                        System.out.println(e);
+                        e.printStackTrace();
+                    }
+                    
+                    try {
+                        opslog.flush();
+                        opslog.close();
+                    } catch(Exception e2) {}
+                    System.exit(1);
+                }
+            }));
+        }
+
+        for (int i=0;i<this.args.settings.edge_readers;i++) {
+            final var j=thread_id++;
+            edge_consumers.add(new Thread(() -> { 
+                try {
+                    readEdgeProcess(j);
+                } catch(Exception e) {
+                    synchronized(this) {
+                        System.out.println("=== err on readProcess");
+                        System.out.println(e);
+                        e.printStackTrace();
+                    }
+                    try {
+                        opslog.flush();
+                        opslog.close();
+                    } catch(Exception e2) {}
+                    System.exit(1);
+                }
+            }));
+        }
+
+        for (int i=0;i<this.args.settings.hist_readers;i++) {
+            final var j=thread_id++;
+            hist_consumers.add(new Thread(() -> { 
+                try {
+                    readHistProcess(j);
+                } catch(Exception e) {
+                    synchronized(this) {
+                        System.out.println("=== err on readProcess");
+                        System.out.println(e);
+                        e.printStackTrace();
+                    }
+                    try {
+                        opslog.flush();
+                        opslog.close();
+                    } catch(Exception e2) {}
+                    System.exit(1);
+                }
+            }));
+        }
+        
+        for (var th : producers) {
+            th.start();
+        }
+
+        for (var th : edge_consumers) {
+            th.start();
+        }
+
+        for (var th : hist_consumers) {
+            th.start();
+        }
+    }
+
+    public void stop() throws Exception {
+        is_active = false;
+        
+        Thread.sleep(1000);
+        if (opslog != null) {
+            opslog.flush();
+        }
+
+        for (var th : producers) {
+            th.join();
+        }
+
+        for (var th : edge_consumers) {
+            th.join();
+        }
+
+        for (var th : hist_consumers) {
+            th.join();
+        }
+
+        if (opslog != null) {
+            opslog.flush();
+            opslog.close();
+        }
+    }
+
+    public synchronized HashMap<String, App.OpsInfo> get_ops_info() {
+        HashMap<String, App.OpsInfo> result = new HashMap<>();
+        for (Integer key : ops_info.keySet()) {
+            result.put("" + key, ops_info.get(key).copy());
+        }
+        return result;
+    }
+
+    private String key(int seq) {
+        return "key" + (seq % 5);
+    }
+
+    private void writeProcess(int wid) throws Exception {
+        Random random =  new Random();
+
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, args.brokers);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
+        
+        // default value: 600000
+        props.put(ProducerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG, 60000);
+        // default value: 120000
+        props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 10000);
+        // default value: 0
+        props.put(ProducerConfig.LINGER_MS_CONFIG, 0);
+        // default value: 60000
+        props.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 10000);
+        // default value: 1000
+        props.put(ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, 1000);
+        // default value: 50
+        props.put(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG, 50);
+        // default value: 30000
+        props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, 10000);
+        // default value: 100
+        props.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 100);
+        // default value: 300000
+        props.put(ProducerConfig.METADATA_MAX_AGE_CONFIG, 10000);
+        // default value: 300000
+        props.put(ProducerConfig.METADATA_MAX_IDLE_CONFIG, 10000);
+        
+        props.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, 5);
+        props.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
+        props.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "tx-" + wid);
+    
+    
+        Producer<String, String> producer = null;
+    
+        log(wid, "started\t" + args.server + "\twriter");
+    
+        var seq = 0;
+        var ltid = 0;
+        var retry = false;
+        
+        while (is_active) {
+            try {
+                if (producer == null) {
+                    log(wid, "constructing");
+                    producer = new KafkaProducer<>(props);
+                    producer.initTransactions();
+                    log(wid, "constructed");
+                    continue;
+                }
+            } catch (Exception e1) {
+                var eid = get_error_id();
+                synchronized(this) {
+                    System.out.println("=== " + eid + " err on constructing KafkaProducer");
+                    System.out.println(e1);
+                    e1.printStackTrace();
+                }
+                
+                log(wid, "err\t" + eid);
+                try {
+                    if (producer != null) {
+                        producer.close();
+                    }
+                } catch(Exception e2) { }
+                producer = null;
+                continue;
+            }
+
+            var should_abort = false;
+            if (!retry) {
+                ltid++;
+                should_abort = random.nextInt(2)==0;
+            }
+    
+            var is_err = false;
+
+            log(wid, "tx");
+            producer.beginTransaction();
+
+            Future<RecordMetadata> of = null;
+            long offset=0;
+
+            try {
+                for (int i=0;i<10;i++) {
+                    var n = seq + i;
+                    var key = this.key(n);
+                    var marker = retry ? "r" : "c";
+                    marker = (should_abort ? "a": marker);
+                    log(wid, "log\tput\t" + key + "\t" + ltid + "\t" + n + "\t" + marker);
+                    of = producer.send(new ProducerRecord<String, String>(args.topic, key, "" + wid + "\t" + ltid + "\t" + n + "\t" + marker + "\t" + randomString(random, 1024)));
+                }
+                offset = of.get().offset();
+            } catch (Exception e1) {
+                var eid = get_error_id();
+                log(wid, "log\terr\t" + eid);
+                synchronized(this) {
+                    System.out.println("=== " + eid + " error on produce => aborting tx");
+                    System.out.println(e1);
+                    e1.printStackTrace();
+                }
+                is_err = true;
+            }
+
+            if (should_abort || is_err) {
+                try {
+                    log(wid, "brt");
+                    producer.abortTransaction();
+                    log(wid, "ok");
+                    if (is_err) {
+                        failed(wid);
+                    } else {
+                        succeeded(wid);
+                    }
+                } catch (Exception e2) {
+                    var eid = get_error_id();
+                    synchronized(this) {
+                        System.out.println("=== " + eid + " error on abort => reset producer");
+                        System.out.println(e2);
+                        e2.printStackTrace();
+                    }
+                    log(wid, "err\t" + eid);
+                    failed(wid);
+                    try {
+                        producer.close();
+                    } catch (Exception e3) {}
+                    producer = null;
+                }
+
+                if (!should_abort) {
+                    retry = true;
+                }
+    
+                continue;
+            }
+
+            synchronized (this) {
+                committing_ltid.put(wid, ltid);
+            }
+    
+            try {
+                log(wid, "cmt");
+                producer.commitTransaction();
+                log(wid, "ok\t" + offset);
+                succeeded(wid);
+            } catch (Exception e1) {
+                var eid = get_error_id();
+                synchronized(this) {
+                    System.out.println("=== " + eid + " error on commit => reset producer");
+                    System.out.println(e1);
+                    e1.printStackTrace();
+                }
+                log(wid, "err\t" + eid);
+                failed(wid);
+                try {
+                    producer.close();
+                } catch (Exception e3) {}
+                producer = null;
+                retry = true;
+                continue;
+            }
+
+            synchronized(this) {
+                if (offset > last_offset) {
+                    last_offset = offset;
+                }
+            }
+
+            seq += 10;
+            retry = false;
+
+            synchronized (this) {
+                committing_ltid.remove(wid);
+                last_committed_seq.put(wid, seq - 1);
+            }
+        }
+    
+        if (producer != null) {
+            try {
+                producer.close();
+            } catch (Exception e) { }
+        }
+    }
+
+    static class WriterState {
+        public int last_seen_seq;
+        public int last_seen_ltid;
+    }
+
+    private void readHistProcess(int rid) throws Exception {
+        log(rid, "started\t" + args.server + "\tconsumer\thist");
+        
+        while (is_active) {
+            readProcess(rid, last_offset);
+            Thread.sleep(1000);
+        }
+    }
+
+    private void readEdgeProcess(int rid) throws Exception {
+        log(rid, "started\t" + args.server + "\tconsumer\tedge");
+        
+        while (is_active) {
+            readProcess(rid, Long.MAX_VALUE);
+        }
+    }
+    
+    private void readProcess(int rid, long boundary) throws Exception {
+        var tp = new TopicPartition(args.topic, 0);
+        var tps = Collections.singletonList(tp);
+        
+        Properties props = new Properties();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, args.brokers);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+        props.put(
+            ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+            "org.apache.kafka.common.serialization.StringDeserializer");
+        props.put(
+            ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            "org.apache.kafka.common.serialization.StringDeserializer");
+        // default value: 540000
+        props.put(ConsumerConfig.CONNECTIONS_MAX_IDLE_MS_CONFIG, 60000);
+        // default value: 60000
+        props.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, 10000);
+        // default value: 500
+        props.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, 500);
+        // default value: 300000
+        props.put(ConsumerConfig.METADATA_MAX_AGE_CONFIG, 10000);
+        // default value: 1000
+        props.put(ConsumerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, 1000);
+        // default value: 50
+        props.put(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG, 50);
+        // defaut value: 30000
+        props.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG, 10000);
+        // default value: 100
+        props.put(ConsumerConfig.RETRY_BACKOFF_MS_CONFIG, 100);
+
+        KafkaConsumer<String, String> consumer = null;
+
+        long prev_offset = -1;
+        HashMap<Integer, WriterState> writers = new HashMap<>();
+        
+        long last_success_us = System.nanoTime() / 1000;
+
+        while (is_active) {
+            var now_us = Math.max(last_success_us, System.nanoTime() / 1000);
+            if (now_us - last_success_us > 10 * 1000 * 1000) {
+                consumer = null;
+                last_success_us = now_us;
+            }
+
+            try {
+                if (consumer == null) {
+                    log(rid, "constructing");
+                    consumer = new KafkaConsumer<>(props);
+                    consumer.assign(tps);
+                    if (prev_offset == -1) {
+                        consumer.seekToBeginning(tps);
+                    } else {
+                        consumer.seek(tp, prev_offset+1);
+                    }
+                    log(rid, "constructed");
+                    continue;
+                }
+            } catch (Exception e) {
+                var eid = get_error_id();
+                log(rid, "err\t" + eid);
+
+                synchronized(this) {
+                    System.out.println("=== " + eid + " err on constructing KafkaConsumer");
+                    System.out.println(e);
+                    e.printStackTrace();
+                }
+
+                failed(rid);
+                continue;
+            }
+
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(10000));
+            var it = records.iterator();
+            while (it.hasNext()) {
+                last_success_us = System.nanoTime() / 1000;
+                var record = it.next();
+
+                long offset = record.offset();
+
+                if (offset >= boundary) {
+                    return;
+                }
+                
+                if (offset < prev_offset) {
+                    violation(rid, "TODO-0");
+                }
+
+                var key = record.key();
+                String[] parts = record.value().split("\t");
+                int wid = Integer.parseInt(parts[0]);
+                int ltid = Integer.parseInt(parts[1]);
+                int seq = Integer.parseInt(parts[2]);
+                if (parts[3].equals("a")) {
+                    log(rid, "log\tread\tkey=" + key + " " + wid + ":" + ltid + ":" + seq + ":" + parts[3] + "@" + record.offset());
+                    violation(rid, "read aborted record");
+                }
+
+                synchronized(this) {
+                    if (this.last_committed_seq.containsKey(wid)) {
+                        if (this.last_committed_seq.get(wid) < seq) {
+                            if (!this.committing_ltid.containsKey(wid)) {
+                                violation(rid, "TODO-4");
+                            }
+                            if (this.committing_ltid.get(wid) != ltid) {
+                                violation(rid, "TODO-5");
+                            }
+                        }
+                    }
+                }
+
+                if (boundary == Long.MAX_VALUE) {
+                    log(rid, "log\tread\tkey=" + key + " " + wid + ":" + ltid + ":" + seq + ":" + parts[3] + "@" + record.offset());
+                }
+
+                WriterState state;
+                if (writers.containsKey(wid)) {
+                    state = writers.get(wid);
+
+                    if (state.last_seen_seq + 1 != seq) {
+                        log(rid, "log\tgap");
+                    }
+
+                    if (state.last_seen_ltid > ltid) {
+                        violation(rid, "observed " + ltid + " while already saw " + state.last_seen_ltid);
+                    }
+                    if (state.last_seen_ltid < ltid) {
+                        if (state.last_seen_seq >= seq) {
+                            violation(rid, "observed " + ltid + "/" + seq + " while already saw " + state.last_seen_ltid + "/" + state.last_seen_seq);
+                        }
+                    }
+                    if (state.last_seen_ltid == ltid) {
+                        if (state.last_seen_seq >= seq) {
+                            if (!parts[3].equals("r")) {
+                                violation(rid, "observed " + ltid + "/" + seq + " while already saw " + state.last_seen_ltid + "/" + state.last_seen_seq + " without retry");
+                            }
+                        }
+                    }
+                } else {
+                    state = new WriterState();
+                    writers.put(wid, state);
+                }
+
+                state.last_seen_seq = seq;
+                state.last_seen_ltid = ltid;
+                
+                prev_offset = offset;
+            }
+        }
+    }
+}


### PR DESCRIPTION
`tx_compact` workload tests a combination of transactions and compaction. 

The workload  has several types of threads / clients:
    
`writeProcess` writes an increasing monotonic sequence (0,1,2,3) in the txn batches of 10. If a commit fails the writer retries the same batch with a retry marker and the same logical tx id (ltid). Each record has a key which is calculated as a remainder of the seq number (seq%5). With a 50% chance `writeProcess` may abort a transaction; when it happens it retries it with the same seq batch.

`readEdgeProcess` continuously reads from the log and checks for obvious consistency violations:
- offsets are strictly increasing
- seq are increasing except the case when it's a retry of a failed write which has actually passed; to differentiate a violation from the retry `readEdgeProcess` checks the ltid and the retry marker
- gaps in seq numbers are allowed because they may be caused by the compaction
- the read record isn't from the aborted batch
- the read record was committed (attempted to commit)

`readHistProcess` is the same as `readEdgeProcess` but it takes latest known offset, reads from the beginning up to that offset and then retry the read with new latest known offset etc.

After the experiment is over the test reads from the log, keeps the last value per each key and checks that it matches the latest attempted write.

Force pushes:
- [update randomString to generate human readable strings](https://github.com/redpanda-data/chaos/compare/7f6ef688051b391505b21d03462e842fdc90be90..af930dbbb41faf815b3991c87995a3d5a85a8ad0)