### PR TITLE
arm64: compile & install librdkafka

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -20,6 +20,12 @@ COPY --chown=ubuntu:ubuntu control /mnt/vectorized/control
 RUN chown ubuntu:ubuntu -R /mnt/vectorized/control
 RUN pip3 install sh
 RUN pip3 install flask
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends gcc git libssl-dev g++ make && \
+  cd /tmp && git clone https://github.com/edenhill/librdkafka.git && \
+  cd librdkafka && git checkout tags/v1.9.0 && \
+  ./configure --prefix=/usr && make -j4 && make install && \
+  cd ../ && rm -rf librdkafka
 RUN pip3 install confluent_kafka
 RUN mkdir -p /mnt/vectorized/workloads
 COPY workloads /mnt/vectorized/workloads

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -24,6 +24,12 @@ COPY docker/control/test.suite.sh /mnt/vectorized/test.suite.sh
 RUN pip3 install sh
 RUN pip3 install flask
 RUN pip3 install pyyaml
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends gcc git libssl-dev g++ make && \
+  cd /tmp && git clone https://github.com/edenhill/librdkafka.git && \
+  cd librdkafka && git checkout tags/v1.9.0 && \
+  ./configure --prefix=/usr && make -j4 && make install && \
+  cd ../ && rm -rf librdkafka
 RUN pip3 install confluent_kafka
 COPY --chown=ubuntu:ubuntu harness /mnt/vectorized/harness
 COPY --chown=ubuntu:ubuntu suites /mnt/vectorized/suites


### PR DESCRIPTION
pip packages in aarch64 doesn't ship the binaries/headers needed for the package to install. Rather git clone/compile and install the version of librdkafka needed for confluent_kafka to work.