### PR TITLE
Prevent interruptions caused by UNKNOWN_TOPIC_OR_PARTITION 

### DIFF
--- a/harness/chaos/workloads/tx_subscribe/log_utils.py
+++ b/harness/chaos/workloads/tx_subscribe/log_utils.py
@@ -38,7 +38,9 @@ threads = {
         State.STARTED: [State.CONSTRUCTING],
         State.CONSTRUCTING: [State.CONSTRUCTED, State.ERROR],
         State.CONSTRUCTED: [State.SEND, State.CONSTRUCTING],
-        State.SEND: [State.OK, State.ERROR],
+        State.SEND: [State.ABORT, State.COMMIT, State.ERROR],
+        State.ABORT: [State.OK, State.ERROR],
+        State.COMMIT: [State.OK, State.ERROR],
         State.OK: [State.SEND, State.CONSTRUCTING],
         State.ERROR: [State.CONSTRUCTING]
     },

--- a/suites/test_suite_idempotency.json
+++ b/suites/test_suite_idempotency.json
@@ -18,7 +18,10 @@
     ],
     "settings": {
         "test": {
-            "remove_logs_on_success": true
+            "remove_logs_on_success": true,
+            "log-level": {
+                "default": "info"
+            }
         },
         "suite": {
             "should_retry_on_transient_errors": true,

--- a/suites/test_suite_list_offsets.json
+++ b/suites/test_suite_list_offsets.json
@@ -9,7 +9,10 @@
     ],
     "settings": {
         "test": {
-            "remove_logs_on_success": true
+            "remove_logs_on_success": true,
+            "log-level": {
+                "default": "info"
+            }
         },
         "suite": {
             "should_retry_on_transient_errors": true,

--- a/suites/test_suite_reads_writes.json
+++ b/suites/test_suite_reads_writes.json
@@ -17,7 +17,10 @@
     ],
     "settings": {
         "test": {
-            "remove_logs_on_success": true
+            "remove_logs_on_success": true,
+            "log-level": {
+                "default": "info"
+            }
         },
         "suite": {
             "should_retry_on_transient_errors": true,

--- a/suites/test_suite_rw_subscribe.json
+++ b/suites/test_suite_rw_subscribe.json
@@ -19,7 +19,10 @@
     ],
     "settings": {
         "test": {
-            "remove_logs_on_success": true
+            "remove_logs_on_success": true,
+            "log-level": {
+                "default": "info"
+            }
         },
         "suite": {
             "should_retry_on_transient_errors": true,


### PR DESCRIPTION
When a client commits a transaction the commit method waits until the pending publish futures are resolved. However if a future throws UnknownTopicOrPartitionException (which is supposed to be retryable) the commit methods fails too and the only thing to do is to retire current session and to create a new producer.

We want to avoid interruptions and creating a new producer so we use a workaround: we explicitly wait until the futures are resolved before invoking commit. In case a future fails we invoke abort instead of commit and continue using the same producer.