### PR TITLE
entrypoint.sh: Use docker hostname for advertised APIs

### DIFF
--- a/docker/redpanda/entrypoint.sh
+++ b/docker/redpanda/entrypoint.sh
@@ -67,6 +67,8 @@ rpk config set redpanda.enable_leader_balancer false
 rpk config set redpanda.enable_auto_rebalance_on_node_add false
 rpk config set redpanda.enable_idempotence true
 rpk config set redpanda.enable_transactions true
+rpk config set redpanda.advertised_rpc_api "{address: $me, port: 33145}"
+rpk config set redpanda.advertised_kafka_api "[{address: $me, port: 9092}]"
 rpk config set redpanda.data_directory "/mnt/vectorized/redpanda/data"
 rpk config set rpk.coredump_dir "/mnt/vectorized/redpanda/coredump"
 echo "setting production mode"


### PR DESCRIPTION
A recent change[1] outlawed the use of `0.0.0.0` as hostname for advertised APIs. A subsequent change[2] adjusted some rpk defaults to reflect that.

This change, in turn, makes `hostname:port` explicit for kafka and rpc advertised addresses, as the new rpk default (`127.0.0.1`) is no longer suitable for this environment.

[1] https://github.com/redpanda-data/redpanda/pull/14179
[2] https://github.com/redpanda-data/redpanda/commit/b4514f4a443c09214a3c025b07f7ffaac13999ec