### PR TITLE
update chaos infra to handle need for 3 deb (not just 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ workloads/tx-poll/target/
 workloads/tx-streaming/target/
 workloads/tx-subscribe/target/
 __pycache__
+**/.idea
+venv

--- a/README.md
+++ b/README.md
@@ -1,9 +1,28 @@
 # How to use chaos testing
 
-Set `DEB_PATH` with path to the redpanda deb package, e.g.
+Create a directory `DEB_DIR` to house required deb packages. `DEB_DIR` must be set in environment
+when chaos tests are started.
 
+Example:
 ```
-export DEB_PATH="$HOME/redpanda_21.11.5-1-af88fa16_amd64.deb"
+export DEB_DIR=/var/tmp/my_chaos_debs/
+mkdir $DEB_DIR
+```
+
+Place Redpanda .deb files into /var/tmp/my_chaos_deb/.
+
+For the latest Redpanda versions, there should be:
+* `$DEB_DIR/redpanda.deb`
+* `$DEB_DIR/redpanda-tuner.deb`
+* `$DEB_DIR/redpanda-rpk.deb`
+
+Also set `DEB_FILE_LIST` variable to the list of deb files in `DEB_DIR`, in the desired install (`dpkg -i`) order.
+
+It should be a quoted, space delimited string.
+
+Example:
+```
+export DEB_FILE_LIST="redpanda-rpk.deb redpanda-tuner.deb redpanda.deb"
 ```
 
 ## Test locally (docker & docker-compose)
@@ -15,7 +34,7 @@ Requirements:
 
 Don't forget to add current user to docker group: https://docs.docker.com/engine/install/linux-postinstall
 
-### All in one
+### All in one (with docker-compose)
 
 Run all tests with a single command:
 
@@ -67,23 +86,23 @@ Provision redpanda nodes, client & control node:
 
 Deploy redpanda & test harness:
 
-    ansible-playbook deploy.yml
+    ansible-playbook deploy.yml --key-file=./id_ed25519
 
 Run a default test suite (`suites/test_suite_all.json`):
 
-    ansible-playbook playbooks/test.suite.yml
+    ansible-playbook playbooks/test.suite.yml --key-file=./id_ed25519
 
 Run a default test suite `n` times:
 
-    ansible-playbook playbooks/test.suite.yml -e repeat=n
+    ansible-playbook playbooks/test.suite.yml -e repeat=n --key-file=./id_ed25519
 
 Run a specific test suite:
 
-    ansible-playbook playbooks/test.suite.yml -e suite_path=test_suite_all.json
+    ansible-playbook playbooks/test.suite.yml -e suite_path=test_suite_all.json --key-file=./id_ed25519
 
 Run a specific test:
 
-    ansible-playbook playbooks/test.test.yml -e test_path=writing_kafka_clients/kill_leader.json
+    ansible-playbook playbooks/test.test.yml -e test_path=writing_kafka_clients/kill_leader.json --key-file=./id_ed25519
 
 Copy test & redpanda logs (find them in the `results` folder):
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -52,17 +52,23 @@
 - name: install redpanda
   hosts: redpanda:client:control
   vars:
-    deb_path: "{{ lookup('env', 'DEB_PATH') }}"
-    deb_name: "{{ deb_path | basename }}"
+    deb_dir: "{{ lookup('env', 'DEB_DIR') }}"
+    deb_file_list: "{{ lookup('env', 'DEB_FILE_LIST') | split }}"
   tasks:
-    - name: copy deb
+    - assert:
+        that:
+          - "deb_file_list | length > 0"
+        fail_msg: "Please set DEB_FILE_LIST env var to space delimited string of deb filenames."
+    - name: copy debs
       copy:
-        src: "{{ deb_path }}"
-        dest: /mnt/vectorized/{{ deb_name }}
-    - name: install deb
+        src: "{{ deb_dir }}/{{ item }}"
+        dest: "/mnt/vectorized/{{ item }}"
+      loop: "{{ deb_file_list }}"
+    - name: install debs
       become_user: root
       shell: |
-        dpkg --force-confold -i /mnt/vectorized/{{ deb_name }}
+        dpkg --force-confold -i  /mnt/vectorized/{{ item }}
+      loop: "{{ deb_file_list }}"
     - name: disable redpanda systemd service
       systemd:
         name: redpanda

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -20,10 +20,9 @@ COPY --chown=ubuntu:ubuntu control /mnt/vectorized/control
 RUN chown ubuntu:ubuntu -R /mnt/vectorized/control
 RUN pip3 install 'sh==1.14.3'
 RUN pip3 install flask
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends gcc git libssl-dev g++ make && \
-  cd /tmp && git clone https://github.com/edenhill/librdkafka.git && \
-  cd librdkafka && git checkout tags/v1.9.0 && \
+RUN apt-get update && apt-get install -y --no-install-recommends gcc git libssl-dev g++ make
+RUN cd /tmp && git clone --depth 1 --branch v1.9.0 https://github.com/edenhill/librdkafka.git && \
+  cd librdkafka && \
   ./configure --prefix=/usr && make -j4 && make install && \
   cd ../ && rm -rf librdkafka
 RUN pip3 install 'confluent_kafka==1.9.2'

--- a/docker/client/entrypoint.sh
+++ b/docker/client/entrypoint.sh
@@ -7,12 +7,14 @@ LOG=/mnt/vectorized/entrypoint/entrypoint.log
 
 echo "starting client node" >>$LOG
 
-if [[ ! -r /mnt/vectorized/redpanda.deb ]]; then
-  echo "/mnt/vectorized/redpanda.deb doesn't exist" >>$LOG
-  exit 1
-fi
+for DEB in $DEB_FILE_LIST; do
+  if [[ ! -r "/mnt/vectorized/deb/$DEB" ]]; then
+    echo "/mnt/vectorized/deb/$DEB doesn't exist" >>$LOG
+    exit 1
+  fi
+  dpkg --force-confold -i "/mnt/vectorized/deb/$DEB"
+done
 
-dpkg --force-confold -i /mnt/vectorized/redpanda.deb
 systemctl disable redpanda
 systemctl disable wasm_engine
 

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -24,10 +24,9 @@ COPY docker/control/test.suite.sh /mnt/vectorized/test.suite.sh
 RUN pip3 install 'sh==1.14.3'
 RUN pip3 install flask
 RUN pip3 install pyyaml
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends gcc git libssl-dev g++ make && \
-  cd /tmp && git clone https://github.com/edenhill/librdkafka.git && \
-  cd librdkafka && git checkout tags/v1.9.0 && \
+RUN apt-get update && apt-get install -y --no-install-recommends gcc git libssl-dev g++ make
+RUN cd /tmp && git clone --depth 1 --branch v1.9.0 https://github.com/edenhill/librdkafka.git && \
+  cd librdkafka && \
   ./configure --prefix=/usr && make -j4 && make install && \
   cd ../ && rm -rf librdkafka
 RUN pip3 install 'confluent_kafka==1.9.2'

--- a/docker/control/entrypoint.sh
+++ b/docker/control/entrypoint.sh
@@ -7,12 +7,14 @@ LOG=/mnt/vectorized/entrypoint/entrypoint.log
 
 echo "starting control node" >>$LOG
 
-if [[ ! -r /mnt/vectorized/redpanda.deb ]]; then
-  echo "/mnt/vectorized/redpanda.deb doesn't exist" >>$LOG
-  exit 1
-fi
+for DEB in $DEB_FILE_LIST; do
+  if [[ ! -r "/mnt/vectorized/deb/$DEB" ]]; then
+    echo "/mnt/vectorized/deb/$DEB doesn't exist" >>$LOG
+    exit 1
+  fi
+  dpkg --force-confold -i "/mnt/vectorized/deb/$DEB"
+done
 
-dpkg --force-confold -i /mnt/vectorized/redpanda.deb
 systemctl disable redpanda
 systemctl disable wasm_engine
 

--- a/docker/docker-compose4.yaml
+++ b/docker/docker-compose4.yaml
@@ -2,7 +2,8 @@ version: '3'
 services:
   redpanda1:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 4
@@ -16,10 +17,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda1/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda1/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda2:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 4
@@ -35,10 +37,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda2/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda2/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda3:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 4
@@ -54,10 +57,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda3/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda3/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda4:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 4
@@ -73,10 +77,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda4/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda4/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   client1:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 4
@@ -95,10 +100,11 @@ services:
     volumes:
       - ./docker/bind_mounts/client1/mnt/vectorized/workloads/logs:/mnt/vectorized/workloads/logs
       - ./docker/bind_mounts/client1/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   control:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 4
@@ -119,7 +125,7 @@ services:
     volumes:
       - ./docker/bind_mounts/control/mnt/vectorized/experiments:/mnt/vectorized/experiments
       - ./docker/bind_mounts/control/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
 networks:
   chaos:
     driver: bridge

--- a/docker/docker-compose6.2.yaml
+++ b/docker/docker-compose6.2.yaml
@@ -2,7 +2,8 @@ version: '3'
 services:
   redpanda1:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -16,10 +17,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda1/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda1/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda2:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -35,10 +37,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda2/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda2/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda3:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -54,10 +57,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda3/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda3/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda4:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -73,10 +77,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda4/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda4/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda5:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -92,10 +97,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda5/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda5/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda6:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -111,10 +117,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda6/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda6/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   client1:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -135,10 +142,11 @@ services:
     volumes:
       - ./docker/bind_mounts/client1/mnt/vectorized/workloads/logs:/mnt/vectorized/workloads/logs
       - ./docker/bind_mounts/client1/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   client2:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -159,10 +167,11 @@ services:
     volumes:
       - ./docker/bind_mounts/client2/mnt/vectorized/workloads/logs:/mnt/vectorized/workloads/logs
       - ./docker/bind_mounts/client2/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   control:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -185,7 +194,7 @@ services:
     volumes:
       - ./docker/bind_mounts/control/mnt/vectorized/experiments:/mnt/vectorized/experiments
       - ./docker/bind_mounts/control/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
 networks:
   chaos:
     driver: bridge

--- a/docker/docker-compose6.yaml
+++ b/docker/docker-compose6.yaml
@@ -2,7 +2,8 @@ version: '3'
 services:
   redpanda1:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -16,10 +17,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda1/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda1/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda2:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -35,10 +37,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda2/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda2/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda3:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -54,10 +57,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda3/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda3/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda4:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -73,10 +77,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda4/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda4/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda5:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -92,10 +97,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda5/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda5/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   redpanda6:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -111,10 +117,11 @@ services:
     volumes:
       - ./docker/bind_mounts/redpanda6/mnt/vectorized/redpanda:/mnt/vectorized/redpanda
       - ./docker/bind_mounts/redpanda6/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   client1:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -135,10 +142,11 @@ services:
     volumes:
       - ./docker/bind_mounts/client1/mnt/vectorized/workloads/logs:/mnt/vectorized/workloads/logs
       - ./docker/bind_mounts/client1/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
   control:
     environment:
-      - DEB_PATH
+      - DEB_DIR
+      - DEB_FILE_LIST
     build:
       args:
         REDPANDA_CLUSTER_SIZE: 6
@@ -161,7 +169,7 @@ services:
     volumes:
       - ./docker/bind_mounts/control/mnt/vectorized/experiments:/mnt/vectorized/experiments
       - ./docker/bind_mounts/control/mnt/vectorized/entrypoint:/mnt/vectorized/entrypoint
-      - $DEB_PATH:/mnt/vectorized/redpanda.deb
+      - $DEB_DIR:/mnt/vectorized/deb
 networks:
   chaos:
     driver: bridge

--- a/docker/ready4.sh
+++ b/docker/ready4.sh
@@ -17,7 +17,7 @@ attempt=0
 for node in redpanda1 redpanda2 redpanda3 redpanda4 client1 control; do
   until docker exec $node /bin/bash -c "[ -f /mnt/vectorized/ready ]" 2>/dev/null; do
     echo "node $node isn't initialized"
-    sleep 1s
+    sleep 1
     ((attempt = attempt + 1))
     if [[ $attempt -eq $MAX_ATTEMPS ]]; then
       echo "retry limit exhausted; cluster isn't ready"

--- a/docker/ready6.2.sh
+++ b/docker/ready6.2.sh
@@ -17,7 +17,7 @@ attempt=0
 for node in redpanda1 redpanda2 redpanda3 redpanda4 redpanda5 redpanda6 client1 client2 control; do
   until docker exec $node /bin/bash -c "[ -f /mnt/vectorized/ready ]" 2>/dev/null; do
     echo "node $node isn't initialized"
-    sleep 1s
+    sleep 1
     ((attempt = attempt + 1))
     if [[ $attempt -eq $MAX_ATTEMPS ]]; then
       echo "retry limit exhausted; cluster isn't ready"

--- a/docker/ready6.sh
+++ b/docker/ready6.sh
@@ -17,7 +17,7 @@ attempt=0
 for node in redpanda1 redpanda2 redpanda3 redpanda4 redpanda5 redpanda6 client1 control; do
   until docker exec $node /bin/bash -c "[ -f /mnt/vectorized/ready ]" 2>/dev/null; do
     echo "node $node isn't initialized"
-    sleep 1s
+    sleep 1
     ((attempt = attempt + 1))
     if [[ $attempt -eq $MAX_ATTEMPS ]]; then
       echo "retry limit exhausted; cluster isn't ready"

--- a/docker/rebuild4.sh
+++ b/docker/rebuild4.sh
@@ -2,8 +2,12 @@
 
 set -e
 
-if [ "$DEB_PATH" == "" ]; then
-  echo "env var DEB_PATH must contain a path to redpanda deb file"
+if [ "$DEB_DIR" == "" ]; then
+  echo "env var $DEB_DIR must contain a dir path where deb files live"
+  exit 1
+fi
+if [ "$DEB_FILE_LIST" == "" ]; then
+  echo "env var $DEB_FILE_LIST must contain a list of deb filenames, in space delimited format"
   exit 1
 fi
 
@@ -32,6 +36,6 @@ mkdir -p ./docker/bind_mounts/control/mnt/vectorized/entrypoint
 mkdir -p ./docker/bind_mounts/client1/mnt/vectorized/workloads/logs
 mkdir -p ./docker/bind_mounts/client1/mnt/vectorized/entrypoint
 
-chmod a+rw -R ./docker/bind_mounts
+chmod -R a+rw ./docker/bind_mounts
 
 docker-compose -f docker/docker-compose4.yaml --project-directory . build --build-arg USER_ID=$(id -u $(whoami))

--- a/docker/rebuild6.2.sh
+++ b/docker/rebuild6.2.sh
@@ -29,6 +29,6 @@ for client in client1 client2; do
   mkdir -p ./docker/bind_mounts/$client/mnt/vectorized/entrypoint
 done
 
-chmod a+rw -R ./docker/bind_mounts
+chmod -R a+rw ./docker/bind_mounts
 
 docker-compose -f docker/docker-compose6.2.yaml --project-directory . build --build-arg USER_ID=$(id -u $(whoami))

--- a/docker/rebuild6.sh
+++ b/docker/rebuild6.sh
@@ -2,8 +2,12 @@
 
 set -e
 
-if [ "$DEB_PATH" == "" ]; then
-  echo "env var DEB_PATH must contain a path to redpanda deb file"
+if [ "$DEB_DIR" == "" ]; then
+  echo "env var $DEB_DIR must contain a dir path where deb files live"
+  exit 1
+fi
+if [ "$DEB_FILE_LIST" == "" ]; then
+  echo "env var $DEB_FILE_LIST must contain a list of deb filenames, in space delimited format"
   exit 1
 fi
 
@@ -32,6 +36,6 @@ mkdir -p ./docker/bind_mounts/control/mnt/vectorized/entrypoint
 mkdir -p ./docker/bind_mounts/client1/mnt/vectorized/workloads/logs
 mkdir -p ./docker/bind_mounts/client1/mnt/vectorized/entrypoint
 
-chmod a+rw -R ./docker/bind_mounts
+chmod -R a+rw ./docker/bind_mounts
 
 docker-compose -f docker/docker-compose6.yaml --project-directory . build --build-arg USER_ID=$(id -u $(whoami))

--- a/docker/redpanda/entrypoint.sh
+++ b/docker/redpanda/entrypoint.sh
@@ -7,12 +7,14 @@ LOG=/mnt/vectorized/entrypoint/entrypoint.log
 
 echo "starting redpanda node" >>$LOG
 
-if [[ ! -r /mnt/vectorized/redpanda.deb ]]; then
-  echo "/mnt/vectorized/redpanda.deb doesn't exist" >>$LOG
-  exit 1
-fi
+for DEB in $DEB_FILE_LIST; do
+  if [[ ! -r "/mnt/vectorized/deb/$DEB" ]]; then
+    echo "/mnt/vectorized/deb/$DEB doesn't exist" >>$LOG
+    exit 1
+  fi
+  dpkg --force-confold -i "/mnt/vectorized/deb/$DEB"
+done
 
-dpkg --force-confold -i /mnt/vectorized/redpanda.deb
 systemctl disable redpanda
 systemctl disable wasm_engine
 

--- a/docker/test.all.sh
+++ b/docker/test.all.sh
@@ -5,6 +5,7 @@ set -e
 ./docker/rebuild4.sh
 ./docker/up4.sh
 if ! ./docker/ready4.sh; then
+  echo "cluster did not reach ready state"
   ./docker/down4.sh
   exit 1
 fi


### PR DESCRIPTION
For newer Redpanda versions we will need these debs:
- redpanda
- redpanda-tuner
- redpanda-rpk

But for older Redpanda versions there is only a single deb (`redpanda`).

The Chaos suite's invocation interface has been changed to support both cases.  The env var `DEB_PATH` has been replaced by:
* `DEB_DIR`: directory that contains 1 or more deb files.
* `DEB_FILE_LIST`: a space delim string, listing deb file names within `DEB_DIR`, in the correct "dpkg -i" order. 

This PR plugs the gap for chaos tests. First reported [here](https://redpandadata.slack.com/archives/C06MCRY75U7/p1714049178702429).

[Change needed in vtools.git repo](https://github.com/redpanda-data/vtools/pull/2701) also to set `DEB_DIR`, `DEB_FILE_LIST`).  **This PR should go in at the same time as the vtools one.**

Locally tested the following:
* AWS mode: terraform + ansible
* Docker-compose mode `test.all.sh`