### PR TITLE
[chaos] apt download operations to retry 3 times for anti-flake

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -4,6 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG USER_ID
 ARG REDPANDA_CLUSTER_SIZE
 ENV REDPANDA_CLUSTER_SIZE=${REDPANDA_CLUSTER_SIZE}
+
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
 RUN apt update -y --fix-missing 
 RUN apt upgrade -y
 RUN apt install -f -y

--- a/docker/control/Dockerfile
+++ b/docker/control/Dockerfile
@@ -6,6 +6,8 @@ ARG REDPANDA_CLUSTER_SIZE
 ENV REDPANDA_CLUSTER_SIZE=${REDPANDA_CLUSTER_SIZE}
 ARG WORKLOAD_CLUSTER_SIZE
 ENV WORKLOAD_CLUSTER_SIZE=${WORKLOAD_CLUSTER_SIZE}
+
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
 RUN apt update -y --fix-missing 
 RUN apt upgrade -y
 RUN apt install -f -y

--- a/docker/redpanda/Dockerfile
+++ b/docker/redpanda/Dockerfile
@@ -4,6 +4,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG USER_ID
 ARG REDPANDA_CLUSTER_SIZE
 ENV REDPANDA_CLUSTER_SIZE=${REDPANDA_CLUSTER_SIZE}
+
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
 RUN apt update -y --fix-missing 
 RUN apt upgrade -y
 RUN apt install -f -y


### PR DESCRIPTION
Convo thread here: https://redpandadata.slack.com/archives/C01C2HS9SAV/p1714774270932669

We do not upgrade the Ubuntu version (to 22.04) here, as that has potential to turn into more involved change.