### PR TITLE
wait longer for control node to be up

### DIFF
--- a/docker/client/entrypoint.sh
+++ b/docker/client/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MAX_ATTEMPS=30
+MAX_ATTEMPS=60
 LOG=/mnt/vectorized/entrypoint/entrypoint.log
 
 echo "starting client node" >>$LOG

--- a/docker/control/entrypoint.sh
+++ b/docker/control/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MAX_ATTEMPS=30
+MAX_ATTEMPS=60
 LOG=/mnt/vectorized/entrypoint/entrypoint.log
 
 echo "starting control node" >>$LOG

--- a/docker/control/test.suite.sh
+++ b/docker/control/test.suite.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MAX_ATTEMPS=10
+MAX_ATTEMPS=30
 
 suite_path="/mnt/vectorized/$1"
 repeat=$2

--- a/docker/control/test.test.sh
+++ b/docker/control/test.test.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MAX_ATTEMPS=10
+MAX_ATTEMPS=30
 
 test_path="/mnt/vectorized/$1"
 repeat=$2

--- a/docker/ready4.sh
+++ b/docker/ready4.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MAX_ATTEMPS=40
+MAX_ATTEMPS=60
 
 abort() {
   for node in redpanda1 redpanda2 redpanda3 redpanda4 client1 control; do

--- a/docker/ready6.2.sh
+++ b/docker/ready6.2.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MAX_ATTEMPS=40
+MAX_ATTEMPS=60
 
 abort() {
   for node in redpanda1 redpanda2 redpanda3 redpanda4 redpanda5 redpanda6 client1 client2 control; do

--- a/docker/ready6.sh
+++ b/docker/ready6.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MAX_ATTEMPS=40
+MAX_ATTEMPS=60
 
 abort() {
   for node in redpanda1 redpanda2 redpanda3 redpanda4 redpanda5 redpanda6 client1 control; do

--- a/docker/redpanda/entrypoint.sh
+++ b/docker/redpanda/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MAX_ATTEMPS=30
+MAX_ATTEMPS=60
 LOG=/mnt/vectorized/entrypoint/entrypoint.log
 
 echo "starting redpanda node" >>$LOG


### PR DESCRIPTION
Our v24.1.x nightly chaos runs are failing.  It is very likely that it is because we don't wait long enough for control node to come up, and fail.

```
ESC_bk;t=1717710934267^GESC[0mcontrol node isn't fully initialized; sleeping for 1s
ESC_bk;t=1717710935414^Gcontrol node isn't fully initialized; sleeping for 1s
ESC_bk;t=1717710936415^Gcontrol node isn't fully initialized; sleeping for 1s
ESC_bk;t=1717710937416^Gcontrol node isn't fully initialized; sleeping for 1s
ESC_bk;t=1717710938417^Gcontrol node isn't fully initialized; sleeping for 1s
ESC_bk;t=1717710939418^Gcontrol node isn't fully initialized; sleeping for 1s
ESC_bk;t=1717710940419^Gcontrol node isn't fully initialized; sleeping for 1s
ESC_bk;t=1717710941420^Gcontrol node isn't fully initialized; sleeping for 1s
ESC_bk;t=1717710942421^Gcontrol node isn't fully initialized; sleeping for 1s
ESC_bk;t=1717710943422^Gcontrol node isn't fully initialized; sleeping for 1s
ESC_bk;t=1717710944424^Gcluster isn't ready
ESC_bk;t=1717710944426^GESC[31mtask: Failed to run task "ci:chaos:default"
```

This root cause is consistent with all observations.
* Other stable branches are OK.  (those Redpanda's also start up faster because they don't have `rpk connect` plugin bundled)
* The chaos "test all' panel that runs as part of release RC's are fine, because they have explicit waits for all nodes to be ready (inc. control nodes).  We also wait for much longer (30s, not 10).

This PR wholesale bumps up all wait times to ensure stability.