### PR TITLE
workload: bump kafka client version

### DIFF
--- a/workloads/uber/pom.xml
+++ b/workloads/uber/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>3.0.0</version>
+      <version>3.8.0</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Updated Kafka clients version as the one used by the chaos tests suite was very old.