### PR TITLE
Revert "kafka/logging: bump client logging into DEBUG"

### DIFF
--- a/workloads/uber/src/main/resources/log4j.properties
+++ b/workloads/uber/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 log4j.rootLogger=WARN, stdout
-log4j.logger.org.apache.kafka=DEBUG, stdout
+log4j.logger.org.apache.kafka=INFO, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n


### PR DESCRIPTION
Reverts redpanda-data/chaos#53

reduces artifacts size and disk usage requirements.