### PR TITLE
.github/workflows: remove EOL python versions

### DIFF
--- a/.github/workflows/static_checks_and_tests.yml
+++ b/.github/workflows/static_checks_and_tests.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         # We use 3.7 in CI Chaos jobs
-        python_version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Removing python 3.7 and 3.8 that have been EOL'ed. The CI runner that runs chaos tests runs python 3.9. Having 3.7 in the test matrix here leads to an error

jira: [DEVPROD-3807]

[DEVPROD-3807]: https://redpandadata.atlassian.net/browse/DEVPROD-3807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ