### PR TITLE
remove progress_during_fault from reconfigure_kill_11 tests

### DIFF
--- a/suites/tests/reads_writes/idempotency/reconfigure_kill_11.json
+++ b/suites/tests/reads_writes/idempotency/reconfigure_kill_11.json
@@ -22,7 +22,6 @@
         "alias": "reconfigure_kill_11_data"
     },
     "checks": [
-        { "name": "redpanda_process_liveness" },
-        { "name": "progress_during_fault", "min-delta": 100 }
+        { "name": "redpanda_process_liveness" }
     ]
 }

--- a/suites/tests/reads_writes/reconfigure_kill_11.json
+++ b/suites/tests/reads_writes/reconfigure_kill_11.json
@@ -20,7 +20,6 @@
         "alias": "reconfigure_kill_11_data"
     },
     "checks": [
-        { "name": "redpanda_process_liveness" },
-        { "name": "progress_during_fault", "min-delta": 100 }
+        { "name": "redpanda_process_liveness" }
     ]
 }


### PR DESCRIPTION
The progress_during_fault seems like a copy-pasta from RF=3 reconfigure tests and should not have been included in the reconfigure_kill_11 scenario. With RF=1, killing the sole replica would result in client making zero progress as there is no leader.

This bug was exposed by 9583db98c and only passed before it by accident. It passed because the post_check (wait_details) does not actually wait for reconfiguration to finish, so the kill got executed immediately on the non leader and the progress_during_fault check passed because there was still a leader after kill.

9583db98c added an extra delay (to reset the balancer) and the reconfiguration actually finished and the kill ended up killing the only leader.

We need to fix wait_details() to actually wait for leader but thats for another time, would prefer not to open a can of worms.