### PR TITLE
deflake reconfiguration + leadership change tests

### DIFF
--- a/harness/chaos/redpanda_static_cluster.py
+++ b/harness/chaos/redpanda_static_cluster.py
@@ -244,29 +244,32 @@ class RedpandaCluster:
     def create_topic(self, topic, replication, partitions, cleanup="delete"):
         ssh("ubuntu@" + self.nodes[0].ip, "rpk", "topic", "create", "--brokers", self.brokers(), topic, "-r", replication, "-p", partitions, "-c", f"cleanup.policy={cleanup}")
     
+    def do_reconfigure(self, leader, replicas, topic, partition=0, namespace="kafka", post_action=None, timeout_s=10):
+        payload = []
+        for replica in replicas:
+            payload.append({
+                "node_id": replica.id,
+                "core": 0
+            })
+        r = requests.post(f"http://{leader.ip}:9644/v1/partitions/{namespace}/{topic}/{partition}/replicas", json=payload)
+        if r.status_code != 200:
+            logger.error(f"Can't reconfigure, status:{r.status_code} body:{r.text}")
+            raise Exception(f"Can't reconfigure, status:{r.status_code} body:{r.text}")
+        if post_action is None:
+            return
+        begin = time.time()
+        while True:
+            if time.time() - begin > timeout_s:
+                raise TimeoutException(f"can't reconfigure {namespace}/{topic}/{partition} within {timeout_s} sec")
+            info = self.wait_details(topic, partition=partition, namespace=namespace, timeout_s=timeout_s)
+            if post_action(info):
+                return info
+            logger.debug(f"waiting for reconfigure of {namespace}/{topic}/{partition}: status={info.status} leader={info.leader.id} replicas={len(info.replicas)}")
+            time.sleep(1)
+
     def reconfigure(self, leader, replicas, topic, partition=0, namespace="kafka", post_action=None, timeout_s=10):
         with self.with_balancer_disabled(leader):
-            payload = []
-            for replica in replicas:
-                payload.append({
-                    "node_id": replica.id,
-                    "core": 0
-                })
-            r = requests.post(f"http://{leader.ip}:9644/v1/partitions/{namespace}/{topic}/{partition}/replicas", json=payload)
-            if r.status_code != 200:
-                logger.error(f"Can't reconfigure, status:{r.status_code} body:{r.text}")
-                raise Exception(f"Can't reconfigure, status:{r.status_code} body:{r.text}")
-            if post_action is None:
-                return
-            begin = time.time()
-            while True:
-                if time.time() - begin > timeout_s:
-                    raise TimeoutException(f"can't reconfigure {namespace}/{topic}/{partition} within {timeout_s} sec")
-                info = self.wait_details(topic, partition=partition, namespace=namespace, timeout_s=timeout_s)
-                if post_action(info):
-                    return info
-                logger.debug(f"waiting for reconfigure of {namespace}/{topic}/{partition}: status={info.status} leader={info.leader.id} replicas={len(info.replicas)}")
-                time.sleep(1)
+            return self.do_reconfigure(leader, replicas, topic, partition=partition, namespace=namespace, post_action=post_action, timeout_s=timeout_s)
 
     def _get_stable_details(self, nodes, topic, partition=0, namespace="kafka", replication=None):
         last_leader = -1

--- a/harness/chaos/redpanda_static_cluster.py
+++ b/harness/chaos/redpanda_static_cluster.py
@@ -132,7 +132,7 @@ class RedpandaCluster:
     
     def get_stable_view(self, nodes=None, timeout_s=10):
         if nodes == None:
-            nodes = self.nodes
+            nodes = list(self.nodes)
         begin = time.time()
         while True:
             random.shuffle(nodes)

--- a/harness/chaos/scenarios/abstract_single_fault.py
+++ b/harness/chaos/scenarios/abstract_single_fault.py
@@ -256,13 +256,13 @@ class AbstractSingleFault(ABC):
                 return False
             return all(node.id in is_target_node_id for node in info.replicas)
 
-        self.redpanda_cluster.reconfigure(controller,
-                                          replicas,
-                                          topic,
-                                          partition=partition,
-                                          namespace=namespace,
-                                          timeout_s=timeout_s,
-                                          post_action=check_target_replicas)
+        self.redpanda_cluster.do_reconfigure(controller,
+                                             replicas,
+                                             topic,
+                                             partition=partition,
+                                             namespace=namespace,
+                                             timeout_s=timeout_s,
+                                             post_action=check_target_replicas)
 
     def _transfer(self,
                   new_leader,

--- a/harness/chaos/scenarios/rw_subscribe_single_fault.py
+++ b/harness/chaos/scenarios/rw_subscribe_single_fault.py
@@ -140,33 +140,35 @@ class RWSubscribeSingleFault(AbstractSingleFault):
         internal_nodes = self.redpanda_cluster.nodes[0:3]
         data_nodes = self.redpanda_cluster.nodes[3:]
 
-        # reconfigure id_allocator to use internal_nodes
-        tasks_logger.info(f"reconfigure id_allocator")
-        self._reconfigure(internal_nodes, "id_allocator", partition=0, namespace="kafka_internal", timeout_s=20)
-        # reconfigure consumer groups to use internal_nodes
-        tasks_logger.info(f"reconfigure consumer groups")
-        self._reconfigure(internal_nodes, "__consumer_offsets", partition=0, namespace="kafka", timeout_s=20)
+        controller = self.redpanda_cluster.wait_leader("controller", namespace="redpanda", timeout_s=20)
+        with self.redpanda_cluster.with_balancer_disabled(controller):
+            # reconfigure id_allocator to use internal_nodes
+            tasks_logger.info(f"reconfigure id_allocator")
+            self._reconfigure(internal_nodes, "id_allocator", partition=0, namespace="kafka_internal", timeout_s=20)
+            # reconfigure consumer groups to use internal_nodes
+            tasks_logger.info(f"reconfigure consumer groups")
+            self._reconfigure(internal_nodes, "__consumer_offsets", partition=0, namespace="kafka", timeout_s=20)
 
-        for partition in range(0, self.partitions):
-            tasks_logger.info(f"reconfigure topic {self.topic}/{partition}")
-            self._reconfigure(data_nodes, self.topic, partition=partition, namespace="kafka", timeout_s=20)
-        
-        tasks_logger.info(f"waiting for post reconfigure progress")
-        try:
-            self.workload_cluster.wait_progress(timeout_s=wait_progress_timeout_s)
-        except TimeoutException:
-            raise ProgressException()
+            for partition in range(0, self.partitions):
+                tasks_logger.info(f"reconfigure topic {self.topic}/{partition}")
+                self._reconfigure(data_nodes, self.topic, partition=partition, namespace="kafka", timeout_s=20)
 
-        tasks_logger.info(f"transfer controller leadership to {internal_nodes[0].id}")
-        self._transfer(internal_nodes[0], "controller", partition=0, namespace="redpanda", timeout_s=20)
-        tasks_logger.info(f"transfer id_allocator leadership to {internal_nodes[1].id}")
-        self._transfer(internal_nodes[1], "id_allocator", partition=0, namespace="kafka_internal", timeout_s=20)
-        tasks_logger.info(f"transfer consumer group leadership to {internal_nodes[1].id}")
-        self._transfer(internal_nodes[1], "__consumer_offsets", partition=0, namespace="kafka", timeout_s=20)
+            tasks_logger.info(f"waiting for post reconfigure progress")
+            try:
+                self.workload_cluster.wait_progress(timeout_s=wait_progress_timeout_s)
+            except TimeoutException:
+                raise ProgressException()
 
-        for partition in range(0, self.partitions):
-            tasks_logger.info(f"transfer topic {self.topic}/{partition} leadership to {data_nodes[partition%len(data_nodes)].id}")
-            self._transfer(data_nodes[partition%len(data_nodes)], self.topic, partition=partition, namespace="kafka", timeout_s=20)
+            tasks_logger.info(f"transfer controller leadership to {internal_nodes[0].id}")
+            self._transfer(internal_nodes[0], "controller", partition=0, namespace="redpanda", timeout_s=20)
+            tasks_logger.info(f"transfer id_allocator leadership to {internal_nodes[1].id}")
+            self._transfer(internal_nodes[1], "id_allocator", partition=0, namespace="kafka_internal", timeout_s=20)
+            tasks_logger.info(f"transfer consumer group leadership to {internal_nodes[1].id}")
+            self._transfer(internal_nodes[1], "__consumer_offsets", partition=0, namespace="kafka", timeout_s=20)
+
+            for partition in range(0, self.partitions):
+                tasks_logger.info(f"transfer topic {self.topic}/{partition} leadership to {data_nodes[partition%len(data_nodes)].id}")
+                self._transfer(data_nodes[partition%len(data_nodes)], self.topic, partition=partition, namespace="kafka", timeout_s=20)
 
         tasks_logger.info(f"waiting for post transfer progress")
         try:

--- a/harness/chaos/scenarios/tx_money_single_fault.py
+++ b/harness/chaos/scenarios/tx_money_single_fault.py
@@ -149,47 +149,49 @@ class TxMoneySingleFault(AbstractSingleFault):
         data_nodes = self.redpanda_cluster.nodes[3:]
 
         reconfigure_timeout_s = self.read_config(["settings", "setup", "reconfigure_timeout_s"], 20)
-
-        # reconfigure id_allocator to use internal_nodes
-        self._reconfigure(internal_nodes, "id_allocator", partition=0, namespace="kafka_internal", timeout_s=reconfigure_timeout_s)
-        # reconfigure tx to use internal_nodes
-        self._reconfigure(internal_nodes, "tx", partition=0, namespace="kafka_internal", timeout_s=reconfigure_timeout_s)
-
-        for i in range(0, self.accounts):
-            self._reconfigure(data_nodes, f"acc{i}", partition=0, namespace="kafka", timeout_s=reconfigure_timeout_s)
-        
-        self.workload_cluster.wait_progress(timeout_s=wait_progress_timeout_s)
-
         leadership_transfer_timeout_s = self.read_config(["settings", "setup", "leadship_transfer_timeout_s"], 20)
-        # transfer controller to other[0]
-        self._transfer(
-            internal_nodes[0],
-            "controller",
-            partition=0,
-            namespace="redpanda",
-            timeout_s=leadership_transfer_timeout_s)
-        # transfer id_allocator to other[1]
-        self._transfer(
-            internal_nodes[1],
-            "id_allocator",
-            partition=0,
-            namespace="kafka_internal",
-            timeout_s=leadership_transfer_timeout_s)
-        # transfer tx to other[2]
-        self._transfer(
-            internal_nodes[2],
-            "tx",
-            partition=0,
-            namespace="kafka_internal",
-            timeout_s=leadership_transfer_timeout_s)
 
-        for i in range(0, self.accounts):
+        controller = self.redpanda_cluster.wait_leader("controller", namespace="redpanda", timeout_s=20)
+        with self.redpanda_cluster.with_balancer_disabled(controller):
+            # reconfigure id_allocator to use internal_nodes
+            self._reconfigure(internal_nodes, "id_allocator", partition=0, namespace="kafka_internal", timeout_s=reconfigure_timeout_s)
+            # reconfigure tx to use internal_nodes
+            self._reconfigure(internal_nodes, "tx", partition=0, namespace="kafka_internal", timeout_s=reconfigure_timeout_s)
+
+            for i in range(0, self.accounts):
+                self._reconfigure(data_nodes, f"acc{i}", partition=0, namespace="kafka", timeout_s=reconfigure_timeout_s)
+
+            self.workload_cluster.wait_progress(timeout_s=wait_progress_timeout_s)
+
+            # transfer controller to other[0]
             self._transfer(
-                data_nodes[i%len(data_nodes)],
-                f"acc{i}",
+                internal_nodes[0],
+                "controller",
                 partition=0,
-                namespace="kafka",
+                namespace="redpanda",
                 timeout_s=leadership_transfer_timeout_s)
+            # transfer id_allocator to other[1]
+            self._transfer(
+                internal_nodes[1],
+                "id_allocator",
+                partition=0,
+                namespace="kafka_internal",
+                timeout_s=leadership_transfer_timeout_s)
+            # transfer tx to other[2]
+            self._transfer(
+                internal_nodes[2],
+                "tx",
+                partition=0,
+                namespace="kafka_internal",
+                timeout_s=leadership_transfer_timeout_s)
+
+            for i in range(0, self.accounts):
+                self._transfer(
+                    data_nodes[i%len(data_nodes)],
+                    f"acc{i}",
+                    partition=0,
+                    namespace="kafka",
+                    timeout_s=leadership_transfer_timeout_s)
 
         self.workload_cluster.wait_progress(timeout_s=wait_progress_timeout_s)
         warmup_s = self.read_config(["settings", "setup", "warmup_s"], 20)

--- a/harness/chaos/scenarios/tx_single_topic_single_fault.py
+++ b/harness/chaos/scenarios/tx_single_topic_single_fault.py
@@ -142,24 +142,27 @@ class TxSingleTopicSingleFault(AbstractSingleFault):
         others = [node for node in self.redpanda_cluster.nodes if node.id not in is_topic_node_id]
         if len(others) != 3:
             raise Exception(f"len(others)={len(others)} isn't 3")
-        # reconfigure id_allocator to use other nodes
-        self._reconfigure(others, "id_allocator", partition=0, namespace="kafka_internal", timeout_s=20)
-        # reconfigure tx to use other nodes
-        self._reconfigure(others, "tx", partition=0, namespace="kafka_internal", timeout_s=20)
 
-        try:
-            self.workload_cluster.wait_progress(timeout_s=wait_progress_timeout_s)
-        except TimeoutException:
-            raise ProgressException()
+        controller = self.redpanda_cluster.wait_leader("controller", namespace="redpanda", timeout_s=20)
+        with self.redpanda_cluster.with_balancer_disabled(controller):
+            # reconfigure id_allocator to use other nodes
+            self._reconfigure(others, "id_allocator", partition=0, namespace="kafka_internal", timeout_s=20)
+            # reconfigure tx to use other nodes
+            self._reconfigure(others, "tx", partition=0, namespace="kafka_internal", timeout_s=20)
 
-        # transfer controller to other[0]
-        self._transfer(others[0], "controller", partition=0, namespace="redpanda", timeout_s=10)
+            try:
+                self.workload_cluster.wait_progress(timeout_s=wait_progress_timeout_s)
+            except TimeoutException:
+                raise ProgressException()
 
-        # transfer id_allocator to other[1]
-        self._transfer(others[1], "id_allocator", partition=0, namespace="kafka_internal", timeout_s=10)
-        
-        # transfer tx to other[2]
-        self._transfer(others[2], "tx", partition=0, namespace="kafka_internal", timeout_s=10)
+            # transfer controller to other[0]
+            self._transfer(others[0], "controller", partition=0, namespace="redpanda", timeout_s=10)
+
+            # transfer id_allocator to other[1]
+            self._transfer(others[1], "id_allocator", partition=0, namespace="kafka_internal", timeout_s=10)
+
+            # transfer tx to other[2]
+            self._transfer(others[2], "tx", partition=0, namespace="kafka_internal", timeout_s=10)
 
         try:
             self.workload_cluster.wait_progress(timeout_s=wait_progress_timeout_s)

--- a/harness/chaos/scenarios/tx_subscribe_single_fault.py
+++ b/harness/chaos/scenarios/tx_subscribe_single_fault.py
@@ -153,43 +153,45 @@ class TxSubscribeSingleFault(AbstractSingleFault):
         internal_nodes = self.redpanda_cluster.nodes[0:3]
         data_nodes = self.redpanda_cluster.nodes[3:]
 
-        # reconfigure id_allocator to use internal_nodes
-        tasks_logger.info(f"reconfigure id_allocator")
-        self._reconfigure(internal_nodes, "id_allocator", partition=0, namespace="kafka_internal", timeout_s=20)
-        # reconfigure tx to use internal_nodes
-        tasks_logger.info(f"reconfigure tx coordinator")
-        self._reconfigure(internal_nodes, "tx", partition=0, namespace="kafka_internal", timeout_s=20)
-        # reconfigure consumer groups to use internal_nodes
-        tasks_logger.info(f"reconfigure consumer groups")
-        self._reconfigure(internal_nodes, "__consumer_offsets", partition=0, namespace="kafka", timeout_s=20)
+        controller = self.redpanda_cluster.wait_leader("controller", namespace="redpanda", timeout_s=20)
+        with self.redpanda_cluster.with_balancer_disabled(controller):
+            # reconfigure id_allocator to use internal_nodes
+            tasks_logger.info(f"reconfigure id_allocator")
+            self._reconfigure(internal_nodes, "id_allocator", partition=0, namespace="kafka_internal", timeout_s=20)
+            # reconfigure tx to use internal_nodes
+            tasks_logger.info(f"reconfigure tx coordinator")
+            self._reconfigure(internal_nodes, "tx", partition=0, namespace="kafka_internal", timeout_s=20)
+            # reconfigure consumer groups to use internal_nodes
+            tasks_logger.info(f"reconfigure consumer groups")
+            self._reconfigure(internal_nodes, "__consumer_offsets", partition=0, namespace="kafka", timeout_s=20)
 
-        tasks_logger.info(f"reconfigure topic {self.target}")
-        self._reconfigure(data_nodes, self.target, partition=0, namespace="kafka", timeout_s=20)
-        for partition in range(0, self.partitions):
-            tasks_logger.info(f"reconfigure topic {self.source}/{partition}")
-            self._reconfigure(data_nodes, self.source, partition=partition, namespace="kafka", timeout_s=20)
-        
-        tasks_logger.info(f"waiting for post reconfigure progress")
-        try:
-            self.workload_cluster.wait_progress(timeout_s=wait_progress_timeout_s)
-        except TimeoutException:
-            raise ProgressException()
+            tasks_logger.info(f"reconfigure topic {self.target}")
+            self._reconfigure(data_nodes, self.target, partition=0, namespace="kafka", timeout_s=20)
+            for partition in range(0, self.partitions):
+                tasks_logger.info(f"reconfigure topic {self.source}/{partition}")
+                self._reconfigure(data_nodes, self.source, partition=partition, namespace="kafka", timeout_s=20)
 
-        tasks_logger.info(f"transfer controller leadership to {internal_nodes[0].id}")
-        self._transfer(internal_nodes[0], "controller", partition=0, namespace="redpanda", timeout_s=20)
-        tasks_logger.info(f"transfer id_allocator leadership to {internal_nodes[1].id}")
-        self._transfer(internal_nodes[1], "id_allocator", partition=0, namespace="kafka_internal", timeout_s=20)
-        tasks_logger.info(f"transfer consumer group leadership to {internal_nodes[1].id}")
-        self._transfer(internal_nodes[1], "__consumer_offsets", partition=0, namespace="kafka", timeout_s=20)
-        tasks_logger.info(f"transfer tx coordinator leadership to {internal_nodes[2].id}")
-        self._transfer(internal_nodes[2], "tx", partition=0, namespace="kafka_internal", timeout_s=20)
+            tasks_logger.info(f"waiting for post reconfigure progress")
+            try:
+                self.workload_cluster.wait_progress(timeout_s=wait_progress_timeout_s)
+            except TimeoutException:
+                raise ProgressException()
 
-        tasks_logger.info(f"transfer topic {self.target} leadership to {data_nodes[0].id}")
-        self._transfer(data_nodes[0], self.target, partition=0, namespace="kafka", timeout_s=20)
+            tasks_logger.info(f"transfer controller leadership to {internal_nodes[0].id}")
+            self._transfer(internal_nodes[0], "controller", partition=0, namespace="redpanda", timeout_s=20)
+            tasks_logger.info(f"transfer id_allocator leadership to {internal_nodes[1].id}")
+            self._transfer(internal_nodes[1], "id_allocator", partition=0, namespace="kafka_internal", timeout_s=20)
+            tasks_logger.info(f"transfer consumer group leadership to {internal_nodes[1].id}")
+            self._transfer(internal_nodes[1], "__consumer_offsets", partition=0, namespace="kafka", timeout_s=20)
+            tasks_logger.info(f"transfer tx coordinator leadership to {internal_nodes[2].id}")
+            self._transfer(internal_nodes[2], "tx", partition=0, namespace="kafka_internal", timeout_s=20)
 
-        for partition in range(0, self.partitions):
-            tasks_logger.info(f"transfer topic {self.source}/{partition} leadership to {data_nodes[partition%len(data_nodes)].id}")
-            self._transfer(data_nodes[partition%len(data_nodes)], self.source, partition=partition, namespace="kafka", timeout_s=20)
+            tasks_logger.info(f"transfer topic {self.target} leadership to {data_nodes[0].id}")
+            self._transfer(data_nodes[0], self.target, partition=0, namespace="kafka", timeout_s=20)
+
+            for partition in range(0, self.partitions):
+                tasks_logger.info(f"transfer topic {self.source}/{partition} leadership to {data_nodes[partition%len(data_nodes)].id}")
+                self._transfer(data_nodes[partition%len(data_nodes)], self.source, partition=partition, namespace="kafka", timeout_s=20)
 
         tasks_logger.info(f"waiting for post transfer progress")
         try:


### PR DESCRIPTION
The partition autobalancer was being re-enabled between each individual
reconfigure call. This created a window where the balancer could move
replicas away from the intended nodes before the subsequent leadership
transfers, causing "Node does not exists in configuration" errors.

Split reconfigure() into do_reconfigure() (just the reconfigure logic)
and reconfigure() (wraps do_reconfigure with balancer disable/enable).
_reconfigure() now calls do_reconfigure() directly since callers like
tx_subscribe manage the balancer at a higher scope. Existing callers
in fault files continue to use reconfigure() unchanged.